### PR TITLE
Fixing icon import (+ Async run) when too many entities.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ src/.coding_rules.md
 
 # Internal notes (not pushed)
 /internal/
+
+# Release requirements / design drafts (not pushed)
+/releasereq/

--- a/src/agents/agent_auto_icon_assign/engine.py
+++ b/src/agents/agent_auto_icon_assign/engine.py
@@ -39,6 +39,32 @@ LLM_TIMEOUT = 120
 
 _TRACE_NAME = "auto_icon_assign"
 
+_BASE_MAX_TOKENS = 1024
+_PER_ENTITY_MAX_TOKENS = 80
+# Databricks-hosted Claude endpoints (e.g. databricks-claude-opus-4-7) reject
+# requests whose ``max_tokens`` exceeds the model's output cap (~8192). Going
+# higher returns an opaque 400 Bad Request. When the ontology is too large to
+# fit in one round, the agent naturally batches via the "retry with smaller
+# subset" tool-error feedback loop.
+_ABSOLUTE_MAX_TOKENS = 8192
+
+
+def _compute_max_tokens(n_entities: int) -> int:
+    """Budget enough tokens to emit the full tool-call JSON for N entities.
+
+    The ``assign_icons`` tool-call argument is a JSON object whose size grows
+    roughly linearly with the number of entities (name length + emoji + JSON
+    punctuation). At the default 2048-token budget, ontologies with ~40+
+    entities get the tool-call JSON truncated, which propagates as a
+    ``JSONDecodeError`` → empty ``arguments`` → ``tool_assign_icons()``
+    raising ``TypeError``. We scale with entity count but never exceed the
+    endpoint's documented output cap.
+    """
+    return min(
+        _ABSOLUTE_MAX_TOKENS,
+        _BASE_MAX_TOKENS + _PER_ENTITY_MAX_TOKENS * max(n_entities, 1),
+    )
+
 
 # =====================================================
 # Data classes
@@ -164,6 +190,10 @@ def run_agent(
 
     total_usage: Dict[str, int] = {"prompt_tokens": 0, "completion_tokens": 0}
     tools_supported = True
+    max_tokens = _compute_max_tokens(len(entity_names))
+    logger.info(
+        "Icon Agent: max_tokens=%d for %d entities", max_tokens, len(entity_names)
+    )
 
     def notify(msg: str):
         if on_step:
@@ -191,6 +221,7 @@ def run_agent(
                 messages,
                 tools=send_tools,
                 temperature=0.3,
+                max_tokens=max_tokens,
                 timeout=LLM_TIMEOUT,
                 trace_name=_TRACE_NAME,
             )
@@ -210,6 +241,7 @@ def run_agent(
                         messages,
                         tools=None,
                         temperature=0.3,
+                        max_tokens=max_tokens,
                         timeout=LLM_TIMEOUT,
                         trace_name=_TRACE_NAME,
                     )
@@ -255,10 +287,65 @@ def run_agent(
                 raw_args = func.get("arguments", "{}")
                 tool_id = tc.get("id", "")
 
+                finish_reason = choice.get("finish_reason")
+                truncated = finish_reason == "length"
+
                 try:
                     arguments = json.loads(raw_args)
-                except json.JSONDecodeError:
-                    arguments = {}
+                except json.JSONDecodeError as json_exc:
+                    logger.warning(
+                        "Icon Agent: tool_call '%s' arguments are not valid JSON "
+                        "(%d chars, finish_reason=%s) — almost certainly truncated. "
+                        "Error: %s. First 200: %r  Last 200: %r",
+                        tool_name,
+                        len(raw_args),
+                        finish_reason,
+                        json_exc,
+                        raw_args[:200],
+                        raw_args[-200:],
+                    )
+                    notify("Tool arguments were truncated — asking agent to retry…")
+                    tool_result = json.dumps(
+                        {
+                            "error": (
+                                "Your tool-call arguments were truncated by the "
+                                "token budget and could not be parsed as JSON. "
+                                "Retry assign_icons with a smaller payload: "
+                                "return icons for only a subset of entities, then "
+                                "call assign_icons again for the rest. Prefer "
+                                "short keys (exact entity names) and single "
+                                "emoji values."
+                            )
+                        }
+                    )
+                    result.steps.append(
+                        AgentStep(
+                            step_type="tool_call",
+                            content=f"<truncated, {len(raw_args)} chars>",
+                            tool_name=tool_name,
+                        )
+                    )
+                    result.steps.append(
+                        AgentStep(
+                            step_type="tool_result",
+                            content=tool_result[:300],
+                            tool_name=tool_name,
+                        )
+                    )
+                    messages.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": tool_id,
+                            "content": tool_result,
+                        }
+                    )
+                    continue
+
+                if truncated:
+                    logger.warning(
+                        "Icon Agent: LLM stopped on 'length' but tool args "
+                        "parsed — output may still be incomplete"
+                    )
 
                 notify(f"Calling {tool_name}…")
                 result.steps.append(

--- a/src/agents/engine_base.py
+++ b/src/agents/engine_base.py
@@ -13,10 +13,30 @@ import time
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional
 
+import requests
+
 from back.core.logging import get_logger
 from agents.llm_utils import call_llm_with_retry
 
 logger = get_logger(__name__)
+
+# Endpoints (e.g. databricks-claude-opus-4-7) sometimes reject optional
+# OpenAI-style parameters with a 400 message like:
+#   "Model ... does not support the temperature parameter."
+# We cache such bans per (endpoint, param) pair so subsequent calls skip the
+# offending field proactively instead of re-discovering the 400 every time.
+_UNSUPPORTED_PARAMS: Dict[str, set] = {}
+
+
+def _unsupported_params(endpoint_name: str) -> set:
+    return _UNSUPPORTED_PARAMS.setdefault(endpoint_name, set())
+
+
+def _looks_unsupported(body_text: str, param: str) -> bool:
+    low = (body_text or "").lower()
+    return f"does not support the {param} parameter" in low or (
+        "unsupported" in low and param in low
+    )
 
 
 # =====================================================
@@ -64,25 +84,52 @@ def call_serving_endpoint(
         "Authorization": f"Bearer {token}",
         "Content-Type": "application/json",
     }
+
+    banned = _unsupported_params(endpoint_name)
     payload: Dict[str, Any] = {
         "messages": messages,
         "max_tokens": max_tokens,
-        "temperature": temperature,
     }
+    if "temperature" not in banned and temperature is not None:
+        payload["temperature"] = temperature
     if tools:
         payload["tools"] = tools
 
     logger.info(
-        "%s: POST %s — %d messages, %d tool defs, max_tokens=%d",
+        "%s: POST %s — %d messages, %d tool defs, max_tokens=%d, temperature=%s",
         trace_name,
         endpoint_name,
         len(messages),
         len(tools) if tools else 0,
         max_tokens,
+        payload.get("temperature", "<skipped>"),
     )
 
-    resp = call_llm_with_retry(url, headers, payload, timeout=timeout)
-    return resp.json()
+    try:
+        resp = call_llm_with_retry(url, headers, payload, timeout=timeout)
+        return resp.json()
+    except requests.exceptions.HTTPError as exc:
+        response = exc.response
+        status = response.status_code if response is not None else None
+        if status != 400:
+            raise
+        body_text = response.text if response is not None else ""
+        # Detect and strip parameters the model rejects, then retry once.
+        dropped: List[str] = []
+        for param in ("temperature",):
+            if param in payload and _looks_unsupported(body_text, param):
+                banned.add(param)
+                payload.pop(param, None)
+                dropped.append(param)
+        if not dropped:
+            raise
+        logger.warning(
+            "%s: endpoint rejected unsupported param(s) %s — retrying without them",
+            trace_name,
+            dropped,
+        )
+        resp = call_llm_with_retry(url, headers, payload, timeout=timeout)
+        return resp.json()
 
 
 # =====================================================

--- a/src/agents/llm_utils.py
+++ b/src/agents/llm_utils.py
@@ -73,7 +73,19 @@ def call_llm_with_retry(
                     time.sleep(delay)
                     continue
                 resp.raise_for_status()
-            resp.raise_for_status()
+            if not resp.ok:
+                body_preview = (resp.text or "")[:800]
+                logger.error(
+                    "LLM: HTTP %d from %s — body: %s",
+                    resp.status_code,
+                    url,
+                    body_preview,
+                )
+                raise requests.exceptions.HTTPError(
+                    f"{resp.status_code} Client Error: {resp.reason} for url: {url} "
+                    f"— body: {body_preview}",
+                    response=resp,
+                )
             return resp
         except requests.exceptions.HTTPError as exc:
             status = exc.response.status_code if exc.response is not None else None

--- a/src/agents/tools/icons.py
+++ b/src/agents/tools/icons.py
@@ -6,7 +6,7 @@ caller (route) can apply them to the ontology.
 """
 
 import json
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, Optional
 
 from back.core.logging import get_logger
 from agents.tools.context import ToolContext
@@ -14,16 +14,65 @@ from agents.tools.context import ToolContext
 logger = get_logger(__name__)
 
 
+_ALT_ICON_KEYS = ("mapping", "icon_map", "assignments", "emoji", "emojis")
+
+
 # =====================================================
 # Tool implementation
 # =====================================================
 
 
-def tool_assign_icons(ctx: ToolContext, *, icons: dict, **_kwargs) -> str:
-    """Persist a {entity_name: emoji} mapping into the context for the caller."""
-    if not isinstance(icons, dict):
-        logger.warning("tool_assign_icons: 'icons' is not a dict (%s)", type(icons))
-        return json.dumps({"error": "icons must be a JSON object {name: emoji}"})
+def tool_assign_icons(
+    ctx: ToolContext, *, icons: Optional[dict] = None, **_kwargs
+) -> str:
+    """Persist a {entity_name: emoji} mapping into the context for the caller.
+
+    Robust to common LLM deviations:
+      - ``icons`` missing / ``None`` because the tool-call JSON was truncated
+        (big-ontology case).  Returns a structured error telling the model to
+        retry with a smaller payload, instead of raising ``TypeError``.
+      - ``icons`` shipped under a different key (``mapping``, ``icon_map`` …).
+      - The mapping flattened as top-level kwargs
+        (``{"Customer": "🧑", "Order": "📋"}`` instead of ``{"icons": {...}}``).
+    """
+    if icons is None:
+        for alt in _ALT_ICON_KEYS:
+            candidate = _kwargs.pop(alt, None)
+            if isinstance(candidate, dict):
+                icons = candidate
+                logger.info("tool_assign_icons: recovered icons from '%s' key", alt)
+                break
+
+    if (
+        icons is None
+        and _kwargs
+        and all(isinstance(v, str) for v in _kwargs.values())
+    ):
+        icons = dict(_kwargs)
+        _kwargs = {}
+        logger.info(
+            "tool_assign_icons: recovered icons from flattened kwargs (%d keys)",
+            len(icons),
+        )
+
+    if not isinstance(icons, dict) or not icons:
+        logger.warning(
+            "tool_assign_icons: 'icons' missing/invalid (got %s); "
+            "tool-call arguments were likely truncated by the token budget",
+            type(icons).__name__,
+        )
+        return json.dumps(
+            {
+                "error": (
+                    "Missing or empty 'icons' argument. Your tool-call JSON may "
+                    "have been truncated. Call assign_icons again with a JSON "
+                    "object of the form "
+                    '{"icons": {"Customer": "🧑", "Order": "📋"}}. If the '
+                    "ontology is large, assign entities in smaller batches "
+                    "across successive tool calls."
+                )
+            }
+        )
 
     logger.info("tool_assign_icons: saving %d icon mapping(s)", len(icons))
     logger.debug("tool_assign_icons: %s", icons)

--- a/src/api/routers/internal/ontology.py
+++ b/src/api/routers/internal/ontology.py
@@ -1221,50 +1221,108 @@ async def auto_assign_icons(
     session_mgr: SessionManager = Depends(get_session_manager),
     settings: Settings = Depends(get_settings),
 ):
-    """Use the auto-icon-assign agent to suggest emoji icons for entity names."""
-    with map_route_errors("Auto-assign icons failed", logger):
-        data = await request.json()
-        entity_names = data.get("entity_names", [])
+    """Start the auto-icon-assign agent as a background task.
 
-        if not entity_names:
-            raise ValidationError("No entity names provided")
+    Returns a ``task_id`` immediately; poll ``GET /tasks/{task_id}`` for
+    ``result.icons`` once ``status == "completed"``. Mirrors the wizard
+    ontology generator pattern (``/wizard/generate-async``) so the icon
+    agent is visible in the global task tracker and survives page
+    navigation.
+    """
+    import threading
 
-        domain = get_domain(session_mgr)
-        host, token, llm_endpoint = require_serving_llm(domain, settings)
+    data = await request.json()
+    entity_names = data.get("entity_names", [])
+    if not entity_names:
+        raise ValidationError("No entity names provided")
 
-        logger.info("AutoIcons: launching agent for %d entities", len(entity_names))
+    domain = get_domain(session_mgr)
+    host, token, llm_endpoint = require_serving_llm(domain, settings)
 
-        agent_result = Ontology(domain).assign_icons_with_agent(
-            host=host,
-            token=token,
-            endpoint_name=llm_endpoint,
-            entity_names=entity_names,
-        )
+    tm = get_task_manager()
+    task = tm.create_task(
+        name=f"Assign Icons ({len(entity_names)} entities)",
+        task_type="auto_assign_icons",
+        steps=[
+            {"name": "init", "description": "Preparing agent"},
+            {"name": "agent", "description": "Asking the LLM"},
+            {"name": "apply", "description": "Merging icons"},
+        ],
+    )
+    logger.info(
+        "AutoIcons: task %s created for %d entities",
+        task.id,
+        len(entity_names),
+    )
 
-        if not agent_result.success:
-            logger.warning("AutoIcons: agent failed — %s", agent_result.error)
-            raise InfrastructureError(
-                "Agent failed to assign icons",
-                detail=agent_result.error or None,
+    def run_icons():
+        try:
+            tm.start_task(task.id, "Starting icon agent…")
+
+            def on_step(msg: str):
+                tm.update_progress(task.id, task.progress, msg)
+
+            tm.advance_step(task.id, "Asking the LLM…")
+            agent_result = Ontology(domain).assign_icons_with_agent(
+                host=host,
+                token=token,
+                endpoint_name=llm_endpoint,
+                entity_names=entity_names,
+                on_step=on_step,
             )
 
-        final_map = Ontology.merge_icon_suggestions(entity_names, agent_result.icons)
-        missing = [n for n in entity_names if n not in final_map]
-        if missing:
-            logger.warning("AutoIcons: No icon for: %s", missing)
+            if not agent_result.success:
+                logger.warning(
+                    "AutoIcons[%s]: agent failed — %s",
+                    task.id,
+                    agent_result.error,
+                )
+                tm.fail_task(
+                    task.id,
+                    agent_result.error or "Agent did not produce icons",
+                )
+                return
 
-        logger.info(
-            "AutoIcons: agent completed — %d/%d icons assigned in %d iterations",
-            len(final_map),
-            len(entity_names),
-            agent_result.iterations,
-        )
+            tm.advance_step(task.id, "Merging icons…")
+            final_map = Ontology.merge_icon_suggestions(
+                entity_names, agent_result.icons
+            )
+            missing = [n for n in entity_names if n not in final_map]
+            if missing:
+                logger.warning(
+                    "AutoIcons[%s]: no icon for %d entity(ies): %s",
+                    task.id,
+                    len(missing),
+                    missing,
+                )
 
-        return {
-            "success": True,
-            "icons": final_map,
-            "agent_iterations": agent_result.iterations,
-        }
+            logger.info(
+                "AutoIcons[%s]: completed — %d/%d icons in %d iterations",
+                task.id,
+                len(final_map),
+                len(entity_names),
+                agent_result.iterations,
+            )
+            tm.complete_task(
+                task.id,
+                result={
+                    "icons": final_map,
+                    "missing": missing,
+                    "agent_iterations": agent_result.iterations,
+                    "agent_usage": agent_result.usage,
+                    "agent_steps": serialize_agent_steps(agent_result.steps),
+                },
+                message=(
+                    f"{len(final_map)}/{len(entity_names)} icons assigned "
+                    f"({agent_result.iterations} agent iterations)"
+                ),
+            )
+        except Exception as exc:
+            logger.exception("AutoIcons[%s]: unexpected failure: %s", task.id, exc)
+            tm.fail_task(task.id, "Icon assignment failed unexpectedly")
+
+    threading.Thread(target=run_icons, daemon=True).start()
+    return {"success": True, "task_id": task.id, "message": "Agent task started"}
 
 
 # ===========================================

--- a/src/front/static/ontology/js/ontology-map.js
+++ b/src/front/static/ontology/js/ontology-map.js
@@ -136,6 +136,12 @@ async function initOntologyMap() {
         return;
     }
 
+    // If a previous icon-assignment task is still running, resume monitoring
+    // so the user sees the result land without clicking the button again.
+    if (typeof checkAndResumeIconsTask === 'function') {
+        checkAndResumeIconsTask();
+    }
+
     // Load saved layout
     const savedLayout = await loadMapLayout();
 
@@ -1485,13 +1491,190 @@ async function createInheritanceFromMap(childEntity, parentEntity) {
 }
 
 // =====================================================
-// AUTO-MAP ICONS (via LLM)
+// AUTO-MAP ICONS (via LLM, async background task)
 // =====================================================
+
+// Session-storage key for persisting a running icon task across navigation.
+const ICONS_TASK_KEY = 'ontobricks_icons_task';
+
+// Module-level guard so the monitor loop is started at most once per task.
+let _iconsCurrentTaskId = null;
+
+/**
+ * Restore button state (used after completion, failure, or resume).
+ */
+function _restoreAutoAssignIconsButton() {
+    const btn = document.getElementById('mapAutoAssignIcons');
+    if (btn) {
+        btn.disabled = false;
+        btn.innerHTML = '<i class="bi bi-emoji-smile"></i>';
+    }
+}
+
+/**
+ * Apply an {entityName: emoji} map to OntologyState.config.classes, then
+ * save and refresh the map. Returns the number of icons actually applied.
+ */
+async function _applyIconsToOntologyState(iconMap) {
+    const classes = OntologyState?.config?.classes || [];
+    let assignedCount = 0;
+    for (const cls of classes) {
+        const emoji = iconMap ? iconMap[cls.name] : undefined;
+        if (emoji) {
+            cls.emoji = emoji;
+            assignedCount++;
+        }
+    }
+    if (assignedCount > 0) {
+        if (typeof saveConfigToSession === 'function') {
+            await saveConfigToSession();
+        }
+        initOntologyMap();
+        if (typeof updateClassesList === 'function') {
+            updateClassesList();
+        }
+    }
+    return assignedCount;
+}
+
+/**
+ * Poll /tasks/{taskId} until the icon task terminates, then apply the
+ * result or surface an error. Safe to call after a page reload because
+ * it reads the latest task state on the first poll.
+ */
+async function _monitorIconsTask(taskId) {
+    if (_iconsCurrentTaskId === taskId) {
+        // Already monitoring — avoid stacking loops after a resume.
+        return;
+    }
+    _iconsCurrentTaskId = taskId;
+
+    const pollInterval = 1500;
+    try {
+        while (true) {
+            await new Promise(r => setTimeout(r, pollInterval));
+
+            let task;
+            try {
+                const resp = await fetch(`/tasks/${taskId}`, { credentials: 'same-origin' });
+                const data = await resp.json();
+                if (!data.success || !data.task) {
+                    throw new Error('Task not found');
+                }
+                task = data.task;
+            } catch (err) {
+                console.error('[Map] Icons task polling error:', err);
+                if (typeof showNotification === 'function') {
+                    showNotification('Error monitoring icon task: ' + err.message, 'error', 5000);
+                }
+                sessionStorage.removeItem(ICONS_TASK_KEY);
+                _restoreAutoAssignIconsButton();
+                return;
+            }
+
+            if (task.status === 'running' || task.status === 'pending') {
+                continue;
+            }
+
+            sessionStorage.removeItem(ICONS_TASK_KEY);
+
+            if (task.status === 'completed') {
+                const iconMap = (task.result && task.result.icons) || {};
+                const missing = (task.result && task.result.missing) || [];
+                const applied = await _applyIconsToOntologyState(iconMap);
+
+                if (typeof showNotification === 'function') {
+                    if (applied === 0) {
+                        showNotification('LLM did not return any icons', 'warning', 3000);
+                    } else {
+                        showNotification(
+                            `Mapped icons to ${applied} ${applied === 1 ? 'entity' : 'entities'}`,
+                            'success',
+                            3000,
+                        );
+                    }
+                    if (missing.length > 0) {
+                        showNotification(
+                            `No icon for ${missing.length} ${missing.length === 1 ? 'entity' : 'entities'}`,
+                            'warning',
+                            4000,
+                        );
+                    }
+                }
+                if (typeof refreshTasks === 'function') refreshTasks();
+                return;
+            }
+
+            if (task.status === 'failed') {
+                if (typeof showNotification === 'function') {
+                    showNotification(
+                        'Icon assignment failed: ' + (task.error || task.message || 'Unknown error'),
+                        'error',
+                        5000,
+                    );
+                }
+                if (typeof refreshTasks === 'function') refreshTasks();
+                return;
+            }
+
+            if (task.status === 'cancelled') {
+                if (typeof showNotification === 'function') {
+                    showNotification('Icon assignment was cancelled', 'warning', 3000);
+                }
+                if (typeof refreshTasks === 'function') refreshTasks();
+                return;
+            }
+
+            // Unknown terminal status — bail out.
+            console.warn('[Map] Icons task unexpected status:', task.status);
+            return;
+        }
+    } finally {
+        _iconsCurrentTaskId = null;
+        _restoreAutoAssignIconsButton();
+    }
+}
+
+/**
+ * Resume monitoring a previously-started icon task after a page reload or
+ * view switch. Called from initOntologyMap().
+ */
+async function checkAndResumeIconsTask() {
+    const savedTaskId = sessionStorage.getItem(ICONS_TASK_KEY);
+    if (!savedTaskId) return;
+    try {
+        const resp = await fetch(`/tasks/${savedTaskId}`, { credentials: 'same-origin' });
+        const data = await resp.json();
+        if (!data.success || !data.task) {
+            sessionStorage.removeItem(ICONS_TASK_KEY);
+            return;
+        }
+        const task = data.task;
+        if (task.status === 'running' || task.status === 'pending') {
+            console.log('[Map] Resuming icons task monitoring:', savedTaskId);
+            const btn = document.getElementById('mapAutoAssignIcons');
+            if (btn) {
+                btn.disabled = true;
+                btn.innerHTML = '<span class="spinner-border spinner-border-sm" role="status"></span>';
+            }
+            _monitorIconsTask(savedTaskId);
+        } else if (task.status === 'completed') {
+            const iconMap = (task.result && task.result.icons) || {};
+            sessionStorage.removeItem(ICONS_TASK_KEY);
+            await _applyIconsToOntologyState(iconMap);
+        } else {
+            sessionStorage.removeItem(ICONS_TASK_KEY);
+        }
+    } catch (err) {
+        console.error('[Map] Resume icons task error:', err);
+        sessionStorage.removeItem(ICONS_TASK_KEY);
+    }
+}
 
 /**
  * Auto-map icons to all entities that still have the default icon.
- * Calls the backend LLM endpoint to pick the best emoji for each name,
- * then updates OntologyState, saves to session, and refreshes the map.
+ * Starts the icon agent as a background task, persists task_id to
+ * sessionStorage, and polls /tasks/{id} for the result.
  */
 async function autoAssignEntityIcons() {
     if (window.isActiveVersion === false) return;
@@ -1504,13 +1687,7 @@ async function autoAssignEntityIcons() {
     }
 
     const defaultEmoji = OntologyState.defaultClassEmoji || '📦';
-
-    // Collect entity names that still have the default icon
-    const candidates = classes.filter(cls => {
-        const currentEmoji = cls.emoji || defaultEmoji;
-        return currentEmoji === defaultEmoji;
-    });
-
+    const candidates = classes.filter(cls => (cls.emoji || defaultEmoji) === defaultEmoji);
     if (candidates.length === 0) {
         if (typeof showNotification === 'function') {
             showNotification('All entities already have custom icons', 'info', 2000);
@@ -1518,14 +1695,16 @@ async function autoAssignEntityIcons() {
         return;
     }
 
-    const entityNames = candidates.map(cls => cls.name);
-
-    // Show progress
-    if (typeof showNotification === 'function') {
-        showNotification(`Asking LLM to assign icons for ${entityNames.length} ${entityNames.length === 1 ? 'entity' : 'entities'}...`, 'info', 5000);
+    // A task is already running — don't launch another.
+    if (sessionStorage.getItem(ICONS_TASK_KEY)) {
+        if (typeof showNotification === 'function') {
+            showNotification('Icon assignment already in progress…', 'info', 2500);
+        }
+        return;
     }
 
-    // Disable the button while loading
+    const entityNames = candidates.map(cls => cls.name);
+
     const btn = document.getElementById('mapAutoAssignIcons');
     if (btn) {
         btn.disabled = true;
@@ -1537,62 +1716,36 @@ async function autoAssignEntityIcons() {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ entity_names: entityNames }),
-            credentials: 'same-origin'
+            credentials: 'same-origin',
         });
-
         const result = await response.json();
 
-        if (!result.success) {
+        if (!result.success || !result.task_id) {
             if (typeof showNotification === 'function') {
-                showNotification(result.message || 'Failed to assign icons', 'error', 5000);
+                showNotification(result.message || 'Failed to start icon task', 'error', 5000);
             }
+            _restoreAutoAssignIconsButton();
             return;
         }
 
-        const iconMap = result.icons || {};
-        let assignedCount = 0;
-
-        for (const cls of candidates) {
-            const emoji = iconMap[cls.name];
-            if (emoji) {
-                cls.emoji = emoji;
-                assignedCount++;
-            }
-        }
-
-        if (assignedCount === 0) {
-            if (typeof showNotification === 'function') {
-                showNotification('LLM did not return any icons', 'warning', 3000);
-            }
-            return;
-        }
-
-        // Save and refresh
-        if (typeof saveConfigToSession === 'function') {
-            await saveConfigToSession();
-        }
-
-        initOntologyMap();
-
-        if (typeof updateClassesList === 'function') {
-            updateClassesList();
-        }
-
+        sessionStorage.setItem(ICONS_TASK_KEY, result.task_id);
         if (typeof showNotification === 'function') {
-            showNotification(`Mapped icons to ${assignedCount} ${assignedCount === 1 ? 'entity' : 'entities'}`, 'success', 3000);
+            showNotification(
+                `Assigning icons for ${entityNames.length} ${entityNames.length === 1 ? 'entity' : 'entities'} in the background…`,
+                'info',
+                4000,
+            );
         }
+        if (typeof refreshTasks === 'function') refreshTasks();
+
+        _monitorIconsTask(result.task_id);
 
     } catch (error) {
-        console.error('[Map] Auto-map icons error:', error);
+        console.error('[Map] Auto-map icons start error:', error);
         if (typeof showNotification === 'function') {
-            showNotification('Error calling LLM: ' + error.message, 'error', 5000);
+            showNotification('Error starting icon task: ' + error.message, 'error', 5000);
         }
-    } finally {
-        // Restore button
-        if (btn) {
-            btn.disabled = false;
-            btn.innerHTML = '<i class="bi bi-emoji-smile"></i>';
-        }
+        _restoreAutoAssignIconsButton();
     }
 }
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -186,6 +186,108 @@ class TestOntologyRoutes:
         assert response.status_code == 200
 
 
+class TestAutoAssignIconsAsync:
+    """The icon-assignment endpoint must be non-blocking and task-tracked.
+
+    Regression suite for the async refactor: the endpoint returns a
+    ``task_id`` immediately and the agent work runs on a background
+    thread, so it shows up under ``/tasks`` like the wizard generator.
+    """
+
+    @staticmethod
+    def _wait_for_task(client, task_id, *, timeout=3.0, interval=0.05):
+        import time
+
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            resp = client.get(f"/tasks/{task_id}")
+            if resp.status_code == 200:
+                data = resp.json()
+                task = data.get("task") or {}
+                if task.get("status") in ("completed", "failed", "cancelled"):
+                    return task
+            time.sleep(interval)
+        raise AssertionError(f"Task {task_id} did not terminate within {timeout}s")
+
+    def test_empty_entity_names_rejected(self, client):
+        response = client.post("/ontology/auto-assign-icons", json={"entity_names": []})
+        assert response.status_code == 400
+
+    def test_returns_task_id_and_completes_on_success(self, client):
+        from types import SimpleNamespace
+
+        fake_result = SimpleNamespace(
+            success=True,
+            icons={"Customer": "🧑", "Order": "📋"},
+            steps=[],
+            iterations=1,
+            usage={"prompt_tokens": 10, "completion_tokens": 5},
+            error="",
+        )
+
+        with patch(
+            "api.routers.internal.ontology.require_serving_llm",
+            return_value=("https://h", "t", "ep"),
+        ), patch.object(
+            __import__(
+                "api.routers.internal.ontology", fromlist=["Ontology"]
+            ).Ontology,
+            "assign_icons_with_agent",
+            return_value=fake_result,
+        ):
+            response = client.post(
+                "/ontology/auto-assign-icons",
+                json={"entity_names": ["Customer", "Order"]},
+            )
+
+            assert response.status_code == 200
+            body = response.json()
+            assert body["success"] is True
+            assert isinstance(body.get("task_id"), str) and body["task_id"]
+            assert "icons" not in body, (
+                "Icons must be returned via /tasks/{id}, not inline"
+            )
+
+            task = self._wait_for_task(client, body["task_id"])
+            assert task["status"] == "completed"
+            result = task.get("result") or {}
+            assert result.get("icons") == {"Customer": "🧑", "Order": "📋"}
+            assert result.get("missing") == []
+            assert result.get("agent_iterations") == 1
+
+    def test_agent_failure_marks_task_failed(self, client):
+        from types import SimpleNamespace
+
+        fake_result = SimpleNamespace(
+            success=False,
+            icons={},
+            steps=[],
+            iterations=0,
+            usage={},
+            error="LLM endpoint unreachable",
+        )
+
+        with patch(
+            "api.routers.internal.ontology.require_serving_llm",
+            return_value=("https://h", "t", "ep"),
+        ), patch.object(
+            __import__(
+                "api.routers.internal.ontology", fromlist=["Ontology"]
+            ).Ontology,
+            "assign_icons_with_agent",
+            return_value=fake_result,
+        ):
+            response = client.post(
+                "/ontology/auto-assign-icons",
+                json={"entity_names": ["Customer"]},
+            )
+            assert response.status_code == 200
+            task_id = response.json()["task_id"]
+
+            task = self._wait_for_task(client, task_id)
+            assert task["status"] == "failed"
+
+
 class TestMappingRoutes:
     def test_mapping_page(self, client):
         response = client.get("/mapping/")


### PR DESCRIPTION
when too many entities, it fails with "ERROR    | agents.engine_base | engine_base.dispatch_tool:127 | auto_icon_assign: 'assign_icons' raised exception: tool_assign_icons() missing 1 required keyword-only argument: 'icons'
Traceback (most recent call last):
  File "/app/python/source_code/src/agents/engine_base.py", line 116, in dispatch_tool
    result = handler(ctx, **arguments)"