### PR TITLE
Hf 0.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="src/front/static/global/img/ontobricks-icon.svg" alt="OntoBricks Logo" width="120" height="120">
 </p>
 
-<h1 align="center">OntoBricks 0.2.0</h1>
+<h1 align="center">OntoBricks 0.2.1</h1>
 
 <p align="center">
   <strong>Digital Twin Builder for Databricks</strong>

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License">
   <img src="https://img.shields.io/badge/python-3.10+-blue.svg" alt="Python">
   <img src="https://img.shields.io/badge/fastapi-0.109+-green.svg" alt="FastAPI">
 </p>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ontobricks"
-version = "0.2.0"
+version = "0.2.1"
 description = "Ontology Management Tool for Databricks"
 requires-python = ">=3.10"
 dependencies = [

--- a/src/back/core/databricks/DatabricksAuth.py
+++ b/src/back/core/databricks/DatabricksAuth.py
@@ -163,6 +163,10 @@ class DatabricksAuth:
             "http_path": f"/sql/1.0/warehouses/{self.warehouse_id}",
             "_socket_timeout": _SQL_SOCKET_TIMEOUT,
         }
+        # *** START FIX - CLOUD FETCH WITH DEPLOYED APPS ***
+        if self.is_app_mode:
+            params["use_cloud_fetch"] = False
+        # *** END FIX - CLOUD FETCH WITH DEPLOYED APPS ***
         if self.is_app_mode and self.client_id and self.client_secret:
             params["access_token"] = self.get_oauth_token()
         elif self.token:

--- a/src/mcp-server/app.yaml
+++ b/src/mcp-server/app.yaml
@@ -8,8 +8,14 @@ command:
 
 env:
   # ── Main app URL ──────────────────────────────────────────────
+  # Must point at the SAME OntoBricks app whose UC volume binding
+  # matches this MCP server's REGISTRY_VOLUME_PATH. The MCP forwards
+  # ``registry_catalog/schema/volume`` query params on every
+  # ``/api/v1/...`` call, so a URL pointing at a different app whose
+  # session-default registry differs will silently re-target the wrong
+  # volume and return ``[]`` from ``list_domains``.
   - name: ONTOBRICKS_URL
-    value: "https://ontobricks-2508734981122804.aws.databricksapps.com"
+    value: "https://ontobricks-020-2508734981122804.aws.databricksapps.com"
 
   # ── SQL Warehouse ─────────────────────────────────────────────
   # Injected from the sql-warehouse resource binding.


### PR DESCRIPTION
Why: In Databricks Apps, outbound traffic is sandboxed. The SQL driver’s CloudFetch path tries to pull large results from internal *.storage.cloud.databricks.com hosts, which the app runtime often cannot reach, so queries can fail or hang even though the warehouse URL works.

Fix: When DATABRICKS_APP_PORT is set (app mode), pass use_cloud_fetch=False so results stay on the normal SQL/Thrift path over the workspace host you already use. Local dev leaves CloudFetch on for performance.