### PR TITLE
V0.3.1 fixes

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -14,7 +14,9 @@ This repository uses modular Cursor rules with scoped `.mdc` files (YAML frontma
 
 After ANY code change (feature, fix, refactoring, review, etc.):
 * Update the changelog in /changelogs/:
-    - Use the version (vX.X.X) as the first level for storing the logs. Each application update must be affected to the right version/folder.
+    - Use the version (vX.X.X) as the first level for storing the logs. 
+        - Get and Use the version specified in the pyproject.toml file for each entry
+        - Each application update must be affected to the right version/folder.
     - Use today's date as filename: YYYY-MM-DD.log (for example if i make an update on the version 0.2.1 the 2026 May 20th i should have the file /changelogs/v0.2.1/2026-05-20.log)
     - If the file already exists, append a new section (one file per day).
     - If the file does not exist, create it.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="src/front/static/global/img/ontobricks-icon.svg" alt="OntoBricks Logo" width="120" height="120">
 </p>
 
-<h1 align="center">OntoBricks 0.3.0</h1>
+<h1 align="center">OntoBricks 0.3.1</h1>
 
 <p align="center">
   <strong>Digital Twin Builder for Databricks</strong>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ontobricks"
-version = "0.3.0"
+version = "0.3.1"
 description = "Ontology Management Tool for Databricks"
 requires-python = ">=3.10"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "uvicorn[standard]>=0.27.0",
     "pydantic>=2.5.0",
     "pydantic-settings>=2.1.0",
-    "python-multipart>=0.0.26",
+    "python-multipart>=0.0.27",
     "starlette>=0.35.0",
     "itsdangerous>=2.1.0",
     "jinja2>=3.1.0",
@@ -56,12 +56,21 @@ packages = ["src/back", "src/front", "src/shared", "src/agents", "src/api"]
 
 [tool.uv]
 constraint-dependencies = [
-    "mako>=1.3.11",
+    # CVE-2026-44307: path traversal via backslash URI on Windows in TemplateLookup
+    "mako>=1.3.12",
     "pygments>=2.20.0",
-    # GHSA-rpm5-65cw-6hj4 / SNYK-PYTHON-GITPYTHON-16298057:
-    # command injection via upload_pack / receive_pack kwargs. Pulled in
-    # transitively by mlflow-skinny; force a patched build.
-    "gitpython>=3.1.47",
+    # GHSA-rpm5-65cw-6hj4: command injection via upload_pack/receive_pack kwargs
+    # CVE-2026-44243: path traversal in reference APIs (fixed in 3.1.48)
+    # CVE-2026-44244: newline injection in config_writer().set_value() (fixed in 3.1.49)
+    # GHSA-mv93-w799-cj2w: section param newline bypass → RCE (fixed in 3.1.50, #26)
+    # NOTE: proxy (pypi-proxy.dev.databricks.com) tops out at 3.1.49; bump to
+    # >=3.1.50 once the proxy is updated to close #26 fully.
+    "gitpython>=3.1.49",
+    # GHSA-qccp-gfcp-xxvc / CVE-2026-????: sensitive headers forwarded in proxied
+    # low-level redirects — fixed in urllib3 2.7.0, but the internal proxy
+    # (pypi-proxy.dev.databricks.com) does not carry that version yet.
+    # Re-enable this constraint once the proxy is updated.
+    # "urllib3>=2.7.0",
 ]
 
 [tool.pytest.ini_options]

--- a/releases/ReleaseNotes_V3.3.1.md
+++ b/releases/ReleaseNotes_V3.3.1.md
@@ -1,0 +1,71 @@
+# OntoBricks — Release Notes V3.3.1
+
+**Release window:** May 2026
+**Type:** Hotfix
+**Test status:** 141 cohort tests passed, 0 failed (49 `test_cohort_builder.py`, 31 `test_dtwin_cohort.py`, 34 `test_cohort_models.py`, 24 `test_agent_cohort_tools.py`, 3 `test_agent_cohort_engine.py`).
+
+---
+
+## Highlights
+
+- **Cohort Discovery: predicate namespace fix** — `hasClaim` (and any predicate loaded outside R2RML) now resolves correctly. The engine no longer silently misses triples whose predicate is in ontology-namespace form (`#`) when the lookup key is in data-namespace form (`/`).
+- **Cohort Discovery: cross-namespace predicate fallback** — `CohortBuilder` gains a local-name alias map mirroring the `SparqlTranslator` approach, so predicates from a completely foreign namespace (e.g. `ontobricks.com/ontology#hasclaim` vs. `databricks-ontology.com/Cust360Auto/hasclaim`) resolve via local-name matching.
+- **Cohort designer UX** — attribute dropdowns in the Path "where" filter and the Compatibility section are now scoped to the entity being filtered, not the full ontology property list.
+
+---
+
+## Cohort Discovery — Bug Fixes
+
+### Fix 1: ontology-form predicate silent miss (`CohortBuilder._outgoing_edge_index`)
+
+When data triples were inserted outside the R2RML pipeline (direct insert, W3C OWL round-trip, manual load), their predicates were stored in ontology-namespace form (`…#hasClaim`) while the lookup key produced by `_normalized_links` was in data-namespace form (`…/hasClaim`). This caused a silent `neighbours_raw = 0` and an empty cohort.
+
+**Changes:**
+
+- `src/back/core/graph_analysis/CohortBuilder.py` — `_outgoing_edge_index` promoted from `@staticmethod` to instance method so it can call `self._to_data_uri(pred)`. Every triple predicate is now normalised to data-namespace form when the index is built.
+- `src/front/static/query/js/query-cohorts.js` — `_renderTraceLink` now guards on `in_frontier === 0` before `neighbours_raw === 0`. When the starting frontier is empty the diagnostic message now reads *"the starting frontier for this hop is empty — all members were eliminated before reaching it. Check the compatibility (Stage 3a) filters or the previous hop's target_class."* instead of misleadingly blaming the predicate URI.
+- `tests/test_cohort_builder.py` — 2 new tests: `test_data_with_ontology_form_predicate_is_indexed_correctly`, `test_trace_shows_nonzero_raw_for_ontology_form_predicate`.
+
+### Fix 2: cross-namespace predicate — local-name alias fallback
+
+`_to_data_uri` can only bridge `#` ↔ `/` within the **same** base namespace. When the domain's object property URIs live in a completely different namespace (e.g. inherited shared namespace `ontobricks.com/ontology#`) the first fix was not sufficient.
+
+**Changes:**
+
+- `src/back/core/graph_analysis/CohortBuilder.py`:
+  - `_predicate_alias_map()` — scans loaded triples, builds `{local_name → canonical_data_namespace_uri}`, cached in `self._cache["predicate_alias"]` and invalidated on triple reload.
+  - `_resolve_predicate(uri)` — tries `_to_data_uri` first; if the URI is unchanged (foreign namespace) falls back to the alias map by local name.
+  - `_normalized_links` and `_normalized_compat` updated to use `_resolve_predicate` instead of `_to_data_uri`.
+- `tests/test_cohort_builder.py` — 1 new test: `test_via_from_foreign_namespace_resolved_by_local_name` (exact replica of the `ElectricitySuspended` / `Cust360Auto` production scenario).
+
+---
+
+## Cohort Designer — UX
+
+### Attribute dropdowns scoped to entity
+
+Property dropdowns in the Path "where" filter and the Compatibility section previously listed every property in the ontology regardless of the entity in scope. Users had to scroll through unrelated properties when filtering a specific hop.
+
+**Changes:**
+
+- `src/front/static/query/js/query-cohorts.js`:
+  - New `_dataPropsForClass(classUri)` helper — filters to data properties whose `domain` matches the class, with a full-list fallback when ontology metadata is incomplete.
+  - `_renderHopWhereRow` now calls `_dataPropsForClass(targetClassUri)`.
+  - `_renderCompat` now calls `_dataPropsForClass(this.rule.class_uri)`.
+
+---
+
+## Modified files
+
+| File | Change |
+|------|--------|
+| `src/back/core/graph_analysis/CohortBuilder.py` | Predicate normalisation fixes + alias map |
+| `src/front/static/query/js/query-cohorts.js` | Diagnostic guard + scoped attribute dropdowns |
+| `tests/test_cohort_builder.py` | 3 new regression tests |
+
+---
+
+## Upgrade notes
+
+No schema, API, or configuration changes. Drop-in replacement for v3.3.0.
+If a cohort was returning empty results due to the `hasClaim` predicate mismatch, re-run **Materialise** — no manual data migration required.

--- a/src/back/core/graph_analysis/CohortBuilder.py
+++ b/src/back/core/graph_analysis/CohortBuilder.py
@@ -138,6 +138,67 @@ class CohortBuilder:
             return data_ns + uri[len(self._base_uri):]
         return uri
 
+    def _predicate_alias_map(self) -> Dict[str, str]:
+        """Return ``local_name → canonical_data_namespace_predicate`` built
+        from the triples already loaded into the cache.
+
+        Provides a last-resort fallback for predicate URIs that live in a
+        foreign namespace (e.g. ``https://ontobricks.com/ontology#hasclaim``
+        when the domain's ``base_uri`` is
+        ``https://databricks-ontology.com/Cust360Auto#``).  In that case
+        :meth:`_to_data_uri` cannot bridge the two namespaces, but the local
+        name ``hasclaim`` is the same in both — this map connects them.
+
+        The map is built once and stored in ``self._cache["predicate_alias"]``
+        so subsequent calls are free.  It is empty when no triples are cached
+        yet (callers must invoke :meth:`_load_triples` first).
+        """
+        if "predicate_alias" in self._cache:
+            return self._cache["predicate_alias"]
+        triples: List[Dict[str, str]] = self._cache.get("triples") or []
+        data_ns = self._data_namespace()
+        alias: Dict[str, str] = {}
+        for t in triples:
+            pred = t.get("predicate", "")
+            if not pred or pred == RDF_TYPE:
+                continue
+            norm = self._to_data_uri(pred)
+            local = extract_local_name(norm)
+            if not local:
+                continue
+            # Prefer the data-namespace form when multiple predicates share
+            # the same local name (e.g. if an ontology- and a data-form
+            # triple both exist in the graph).
+            if local not in alias or (data_ns and norm.startswith(data_ns)):
+                alias[local] = norm
+        self._cache["predicate_alias"] = alias
+        return alias
+
+    def _resolve_predicate(self, uri: str) -> str:
+        """Normalise a predicate URI for rule/hop lookup.
+
+        Extends :meth:`_to_data_uri` with a local-name fallback for
+        predicates that belong to a completely different namespace than
+        the domain's ``base_uri``.  This handles the common situation
+        where an ontology's properties were created under a shared /
+        default namespace (``https://ontobricks.com/ontology#name``)
+        while the data triples use the domain-specific data namespace
+        (``https://my-domain.com/Ontology/name``).
+        """
+        result = self._to_data_uri(uri)
+        if result != uri:
+            return result  # successfully normalised by _to_data_uri
+        # _to_data_uri left the URI unchanged — it may be from a foreign
+        # namespace.  Try the local-name alias built from the loaded triples.
+        if uri:
+            local = extract_local_name(uri)
+            if local:
+                alias = self._predicate_alias_map()
+                resolved = alias.get(local)
+                if resolved:
+                    return resolved
+        return result
+
     def _to_ontology_uri(self, uri: str) -> str:
         """Inverse of :meth:`_to_data_uri` — rewrite a data-namespace URI
         back to ontology form (``base_uri`` + ``#`` + local).
@@ -179,6 +240,11 @@ class CohortBuilder:
         ``where[*].property`` rewritten to the data namespace.
         ``target_class`` is left alone — class URIs use the ontology
         form on both sides.
+
+        Uses :meth:`_resolve_predicate` instead of :meth:`_to_data_uri`
+        so that predicates from a foreign namespace (e.g. the shared
+        OntoBricks vocabulary namespace) are resolved via local-name
+        alias against the triples actually present in the graph.
         """
         if not self._base_uri:
             return list(links)
@@ -190,7 +256,7 @@ class CohortBuilder:
                 for w in h.where or []:
                     new_w = CohortCompat(
                         type=w.type,
-                        property=self._to_data_uri(w.property),
+                        property=self._resolve_predicate(w.property),
                         value=w.value,
                         values=w.values,
                         min=w.min,
@@ -200,7 +266,7 @@ class CohortBuilder:
                     new_where.append(new_w)
                 new_path.append(
                     CohortHop(
-                        via=self._to_data_uri(h.via),
+                        via=self._resolve_predicate(h.via),
                         target_class=h.target_class,
                         where=new_where,
                     )
@@ -216,7 +282,7 @@ class CohortBuilder:
         return [
             CohortCompat(
                 type=c.type,
-                property=self._to_data_uri(c.property),
+                property=self._resolve_predicate(c.property),
                 value=c.value,
                 values=c.values,
                 min=c.min,
@@ -744,11 +810,20 @@ class CohortBuilder:
             edges |= s
         return edges
 
-    @staticmethod
     def _outgoing_edge_index(
+        self,
         triples: List[Dict[str, str]],
     ) -> Dict[Tuple[str, str], List[str]]:
-        """Index ``(subject, predicate) -> [object, …]`` for path walking."""
+        """Index ``(subject, predicate) -> [object, …]`` for path walking.
+
+        Predicates are normalised to the data-namespace form via
+        :meth:`_to_data_uri` so that lookups using the normalised ``via``
+        predicate (from :meth:`_normalized_links`) always resolve correctly,
+        regardless of which namespace form the triple store uses.  This
+        matters when data was loaded outside the R2RML pipeline (e.g. direct
+        insert, W3C OWL import) where ontology-namespace predicates (``…#name``)
+        can appear instead of the expected data-namespace form (``…/name``).
+        """
         idx: Dict[Tuple[str, str], List[str]] = {}
         for t in triples:
             subj = t.get("subject")
@@ -758,7 +833,8 @@ class CohortBuilder:
             obj = t.get("object")
             if obj is None:
                 continue
-            idx.setdefault((subj, pred), []).append(obj)
+            norm_pred = self._to_data_uri(pred)
+            idx.setdefault((subj, norm_pred), []).append(obj)
         return idx
 
     def _type_index_for_links(
@@ -1164,6 +1240,8 @@ class CohortBuilder:
         if cached is None:
             cached = self._store.query_triples(self._graph_name) if self._store else []
             self._cache["triples"] = cached
+            # Invalidate predicate alias so it's rebuilt from the fresh triples.
+            self._cache.pop("predicate_alias", None)
         if max_triples is not None and len(cached) > max_triples:
             if allow_overflow:
                 logger.debug(

--- a/src/front/static/query/js/query-cohorts.js
+++ b/src/front/static/query/js/query-cohorts.js
@@ -1733,7 +1733,9 @@ const CohortModule = {
                 Path collapses at hop ${collapsedAt + 1}
                 (<code>${this._esc(this._localName(hops[collapsedAt].via) || '?')}</code>
                 → <code>${this._esc(this._localName(hops[collapsedAt].target_class) || '?')}</code>):
-                ${hops[collapsedAt].neighbours_raw === 0
+                ${hops[collapsedAt].in_frontier === 0
+                    ? 'the starting frontier for this hop is empty — all members were eliminated before reaching it. Check the compatibility (Stage 3a) filters or the previous hop\'s <code>target_class</code>.'
+                    : hops[collapsedAt].neighbours_raw === 0
                     ? 'no neighbours found via this predicate. Check the predicate URI and whether your data actually uses it.'
                     : (hops[collapsedAt].dropped_type === hops[collapsedAt].neighbours_raw
                         ? "every neighbour was rejected by <code>target_class</code>. The hop's target entity URI probably doesn't match the URIs used in <code>rdf:type</code> triples."

--- a/src/front/static/query/js/query-cohorts.js
+++ b/src/front/static/query/js/query-cohorts.js
@@ -110,6 +110,17 @@ const CohortModule = {
         return matched.length ? matched : (this.objectProperties || []);
     },
 
+    _dataPropsForClass(classUri) {
+        const allData = (this.properties || []).filter(p =>
+            !(p.type || p.kind || '').toLowerCase().includes('object')
+        );
+        if (!classUri) return allData;
+        const className = this._classNameByUri(classUri);
+        if (!className) return allData;
+        const matched = allData.filter(p => !p.domain || p.domain === className);
+        return matched.length ? matched : allData;
+    },
+
     _compatibleViaProperties(sourceUri, targetUri) {
         const props = this._objectPropsForSource(sourceUri);
         if (!targetUri) return props;
@@ -861,7 +872,7 @@ const CohortModule = {
     _renderHopWhereRow(linkIdx, hopIdx, whereIdx, w, targetClassUri) {
         const row = document.createElement('div');
         row.className = 'cohort-row cohort-hop-where-row';
-        const propOptions = (this.properties || []).map(p => {
+        const propOptions = this._dataPropsForClass(targetClassUri).map(p => {
             const uri = p.uri || p.iri || p.id || '';
             const lbl = p.label || p.name || uri;
             return `<option value="${this._esc(uri)}" ${uri === w.property ? 'selected' : ''}>${this._esc(lbl)}</option>`;
@@ -968,7 +979,7 @@ const CohortModule = {
             const propSelect = `
                 <select class="form-select form-select-sm cohort-input cohort-compat-prop" data-idx="${i}">
                     <option value="">— property —</option>
-                    ${(this.properties || []).map(p => {
+                    ${this._dataPropsForClass(this.rule.class_uri).map(p => {
                         const uri = p.uri || p.iri || p.id || '';
                         const lbl = p.label || p.name || uri;
                         return `<option value="${this._esc(uri)}" ${uri === cc.property ? 'selected' : ''}>${this._esc(lbl)}</option>`;

--- a/tests/test_cohort_builder.py
+++ b/tests/test_cohort_builder.py
@@ -733,6 +733,159 @@ class TestOntologyDataNamespaceDrift:
         # Without base_uri, the rewrite is skipped → exact-match miss.
         assert result.stats.edge_count == 0
 
+    # --- data loaded with ontology-namespace (# form) predicates -----
+    #
+    # Reproduces the "ElectricitySuspended / hasClaim returns nothing"
+    # production bug: data was not loaded via R2RML but inserted with
+    # ontology-namespace predicates (``…#hasClaim`` instead of
+    # ``…/hasClaim``).  _normalized_links already converts the *rule*
+    # predicate to data form; _outgoing_edge_index must normalise the
+    # *triple* predicate to the same form or the lookup silently misses.
+
+    def _graph_with_ontology_form_predicates(self) -> List[Dict[str, str]]:
+        """Person --#PhasProject--> Project triples where the predicate
+        is in the ontology namespace (``#``), not the data namespace
+        (``/``).  This happens when data is inserted outside the R2RML
+        pipeline, e.g. direct graph insert or W3C OWL round-trip.
+        """
+        return [
+            {"subject": "Alice", "predicate": RDF_TYPE,
+             "object": self.BASE_HASH + "Person"},
+            {"subject": "Bob",   "predicate": RDF_TYPE,
+             "object": self.BASE_HASH + "Person"},
+            {"subject": "Carol", "predicate": RDF_TYPE,
+             "object": self.BASE_HASH + "Person"},
+            {"subject": "P1", "predicate": RDF_TYPE,
+             "object": self.BASE_HASH + "Project"},
+            {"subject": "P2", "predicate": RDF_TYPE,
+             "object": self.BASE_HASH + "Project"},
+            # Predicate in ONTOLOGY (# form) — the new bug scenario.
+            {"subject": "Alice", "predicate": self.BASE_HASH + "PhasProject",
+             "object": "P1"},
+            {"subject": "Bob",   "predicate": self.BASE_HASH + "PhasProject",
+             "object": "P1"},
+            {"subject": "Carol", "predicate": self.BASE_HASH + "PhasProject",
+             "object": "P2"},
+        ]
+
+    def test_via_from_foreign_namespace_resolved_by_local_name(self):
+        """Regression for the ElectricitySuspended / hasClaim production bug.
+
+        The domain's base_uri is ``https://databricks-ontology.com/Cust360Auto#``
+        but ALL object property URIs in the ontology use a shared/default
+        namespace ``https://ontobricks.com/ontology#``.  The data triples use
+        the domain's data namespace as expected.
+
+        ``_to_data_uri`` cannot bridge two completely different namespaces, so
+        ``_resolve_predicate`` must fall back to local-name matching against
+        the triples actually in the graph.
+        """
+        domain_base = "https://databricks-ontology.com/Cust360Auto#"
+        domain_data = "https://databricks-ontology.com/Cust360Auto/"
+        prop_ns = "https://ontobricks.com/ontology#"   # foreign namespace
+        triples = [
+            {"subject": "Alice", "predicate": RDF_TYPE,
+             "object": domain_base + "Customer"},
+            {"subject": "Bob",   "predicate": RDF_TYPE,
+             "object": domain_base + "Customer"},
+            {"subject": "Carol", "predicate": RDF_TYPE,
+             "object": domain_base + "Customer"},
+            {"subject": "Claim1", "predicate": RDF_TYPE,
+             "object": domain_base + "Claim"},
+            {"subject": "Claim1", "predicate": RDF_TYPE,
+             "object": domain_base + "Claim"},
+            {"subject": "Claim2", "predicate": RDF_TYPE,
+             "object": domain_base + "Claim"},
+            # Data triples use the domain data namespace.
+            {"subject": "Alice", "predicate": domain_data + "hasclaim",
+             "object": "Claim1"},
+            {"subject": "Bob",   "predicate": domain_data + "hasclaim",
+             "object": "Claim1"},
+            {"subject": "Carol", "predicate": domain_data + "hasclaim",
+             "object": "Claim2"},
+        ]
+        b = CohortBuilder(
+            store=_store_with(triples), graph_name="g", base_uri=domain_base
+        )
+        rule = CohortRule(
+            id="electricity-suspended",
+            label="Electricity suspended",
+            class_uri=domain_base + "Customer",
+            links=[CohortLink(path=[
+                CohortHop(
+                    via=prop_ns + "hasclaim",     # foreign namespace — the bug
+                    target_class=domain_base + "Claim",
+                ),
+            ])],
+            min_size=2,
+        )
+        result = b.build(rule)
+        assert result.stats.edge_count == 1, (
+            "Expected 1 edge (Alice↔Bob via Claim1). "
+            "neighbours_raw=0 means _resolve_predicate failed to match "
+            "the foreign-namespace 'hasclaim' to the domain data predicate."
+        )
+        assert result.stats.cohort_count == 1
+        cohort_members = {m for c in result.cohorts for m in c.members}
+        assert cohort_members == {"Alice", "Bob"}
+
+    def test_data_with_ontology_form_predicate_is_indexed_correctly(self):
+        """Regression for 'hasClaim returns nothing': data triples carry
+        the ontology-namespace (``#``) predicate form instead of the
+        data-namespace (``/``) form.  The engine must normalise triple
+        predicates when building the outgoing-edge index so the lookup
+        (which uses the data form after ``_normalized_links``) succeeds."""
+        b = self._builder_with_base_uri(
+            self._graph_with_ontology_form_predicates()
+        )
+        rule = CohortRule(
+            id="cohort",
+            label="Cohort",
+            class_uri=self.BASE_HASH + "Person",
+            links=[CohortLink(path=[
+                CohortHop(
+                    via=self.BASE_HASH + "PhasProject",
+                    target_class=self.BASE_HASH + "Project",
+                ),
+            ])],
+            min_size=2,
+        )
+        result = b.build(rule)
+        # Alice + Bob share P1 → cohort {Alice, Bob}; Carol is alone on P2.
+        assert result.stats.edge_count == 1, (
+            "Expected 1 edge — Alice↔Bob via P1. "
+            "neighbours_raw=0 means _outgoing_edge_index failed to "
+            "normalise the ontology-form predicate."
+        )
+        assert result.stats.cohort_count == 1
+        cohort_members = {m for c in result.cohorts for m in c.members}
+        assert cohort_members == {"Alice", "Bob"}
+
+    def test_trace_shows_nonzero_raw_for_ontology_form_predicate(self):
+        """trace_paths must also show neighbours_raw > 0 for the same
+        scenario — the 'no neighbours found via this predicate' message
+        must NOT be shown when the data simply uses ontology-form URIs."""
+        b = self._builder_with_base_uri(
+            self._graph_with_ontology_form_predicates()
+        )
+        out = b.trace_paths(
+            self.BASE_HASH + "Person",
+            [CohortLink(path=[
+                CohortHop(
+                    via=self.BASE_HASH + "PhasProject",
+                    target_class=self.BASE_HASH + "Project",
+                ),
+            ])],
+        )
+        h0 = out["links"][0]["hops"][0]
+        assert h0["in_frontier"] == 3, "all 3 persons should be in frontier"
+        assert h0["neighbours_raw"] == 3, (
+            "must see all 3 ontology-form PhasProject triples after "
+            "normalisation — failing here is the root cause of the "
+            "ElectricitySuspended / hasClaim diagnosis bug"
+        )
+        assert h0["out_frontier"] == 2   # P1, P2
+
     # --- class-URI drift on rdf:type triples -------------------------
     #
     # Reproduces the production "explain says not an instance" bug:

--- a/uv.lock
+++ b/uv.lock
@@ -11,8 +11,8 @@ resolution-markers = [
 
 [manifest]
 constraints = [
-    { name = "gitpython", specifier = ">=3.1.47" },
-    { name = "mako", specifier = ">=1.3.11" },
+    { name = "gitpython", specifier = ">=3.1.49" },
+    { name = "mako", specifier = ">=1.3.12" },
     { name = "pygments", specifier = ">=2.20.0" },
 ]
 
@@ -1248,14 +1248,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.47"
+version = "3.1.49"
 source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/bd/50db468e9b1310529a19fce651b3b0e753b5c07954d486cba31bbee9a5d5/gitpython-3.1.47.tar.gz", hash = "sha256:dba27f922bd2b42cb54c87a8ab3cb6beb6bf07f3d564e21ac848913a05a8a3cd", size = 216978, upload-time = "2026-04-22T02:44:44.059Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/63/210aaa302d6a0a78daa67c5c15bbac2cad361722841278b0209b6da20855/gitpython-3.1.49.tar.gz", hash = "sha256:42f9399c9eb33fc581014bedd76049dfbaf6375aa2a5754575966387280315e1", size = 219367, upload-time = "2026-04-29T00:31:20.478Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/c5/a1bc0996af85757903cf2bf444a7824e68e0035ce63fb41d6f76f9def68b/gitpython-3.1.47-py3-none-any.whl", hash = "sha256:489f590edfd6d20571b2c0e72c6a6ac6915ee8b8cd04572330e3842207a78905", size = 209547, upload-time = "2026-04-22T02:44:41.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/6f/b842bfa6f21d6f87c57f9abf7194225e55279d96d869775e19e9f7236fc5/gitpython-3.1.49-py3-none-any.whl", hash = "sha256:024b0422d7f84d15cd794844e029ffebd4c5d42a7eb9b936b458697ef550a02c", size = 212190, upload-time = "2026-04-29T00:31:18.412Z" },
 ]
 
 [[package]]
@@ -1722,14 +1722,14 @@ wheels = [
 
 [[package]]
 name = "mako"
-version = "1.3.11"
+version = "1.3.12"
 source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/59/8a/805404d0c0b9f3d7a326475ca008db57aea9c5c9f2e1e39ed0faa335571c/mako-1.3.11.tar.gz", hash = "sha256:071eb4ab4c5010443152255d77db7faa6ce5916f35226eb02dc34479b6858069", size = 399811, upload-time = "2026-04-14T20:19:51.493Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/62/791b31e69ae182791ec67f04850f2f062716bbd205483d63a215f3e062d3/mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a", size = 400219, upload-time = "2026-04-28T19:01:08.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/a5/19d7aaa7e433713ffe881df33705925a196afb9532efc8475d26593921a6/mako-1.3.11-py3-none-any.whl", hash = "sha256:e372c6e333cf004aa736a15f425087ec977e1fcbd2966aae7f17c8dc1da27a77", size = 78503, upload-time = "2026-04-14T20:19:53.233Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9", size = 78521, upload-time = "2026-04-28T19:01:10.393Z" },
 ]
 
 [[package]]
@@ -2418,7 +2418,7 @@ wheels = [
 
 [[package]]
 name = "ontobricks"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
@@ -2488,7 +2488,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.1.0" },
     { name = "pyshacl", specifier = ">=0.26.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
-    { name = "python-multipart", specifier = ">=0.0.26" },
+    { name = "python-multipart", specifier = ">=0.0.27" },
     { name = "rdflib", specifier = ">=7.6.0" },
     { name = "real-ladybug", specifier = ">=0.1.0" },
     { name = "requests", specifier = ">=2.33.0" },
@@ -3424,11 +3424,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.26"
+version = "0.0.27"
 source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/9b/f23807317a113dc36e74e75eb265a02dd1a4d9082abc3c1064acd22997c4/python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602", size = 44043, upload-time = "2026-04-27T10:51:26.649Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+    { url = "https://files.pythonhosted.org/packages/99/78/4126abcbdbd3c559d43e0db7f7b9173fc6befe45d39a2856cc0b8ec2a5a6/python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645", size = 29254, upload-time = "2026-04-27T10:51:24.997Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# OntoBricks — Release Notes V3.3.1

**Release window:** May 2026
**Type:** Hotfix
**Test status:** 141 cohort tests passed, 0 failed (49 `test_cohort_builder.py`, 31 `test_dtwin_cohort.py`, 34 `test_cohort_models.py`, 24 `test_agent_cohort_tools.py`, 3 `test_agent_cohort_engine.py`).

---

## Highlights

- **Cohort Discovery: predicate namespace fix** — `hasClaim` (and any predicate loaded outside R2RML) now resolves correctly. The engine no longer silently misses triples whose predicate is in ontology-namespace form (`#`) when the lookup key is in data-namespace form (`/`).
- **Cohort Discovery: cross-namespace predicate fallback** — `CohortBuilder` gains a local-name alias map mirroring the `SparqlTranslator` approach, so predicates from a completely foreign namespace (e.g. `ontobricks.com/ontology#hasclaim` vs. `databricks-ontology.com/Cust360Auto/hasclaim`) resolve via local-name matching.
- **Cohort designer UX** — attribute dropdowns in the Path "where" filter and the Compatibility section are now scoped to the entity being filtered, not the full ontology property list.

---

## Cohort Discovery — Bug Fixes

### Fix 1: ontology-form predicate silent miss (`CohortBuilder._outgoing_edge_index`)

When data triples were inserted outside the R2RML pipeline (direct insert, W3C OWL round-trip, manual load), their predicates were stored in ontology-namespace form (`…#hasClaim`) while the lookup key produced by `_normalized_links` was in data-namespace form (`…/hasClaim`). This caused a silent `neighbours_raw = 0` and an empty cohort.

**Changes:**

- `src/back/core/graph_analysis/CohortBuilder.py` — `_outgoing_edge_index` promoted from `@staticmethod` to instance method so it can call `self._to_data_uri(pred)`. Every triple predicate is now normalised to data-namespace form when the index is built.
- `src/front/static/query/js/query-cohorts.js` — `_renderTraceLink` now guards on `in_frontier === 0` before `neighbours_raw === 0`. When the starting frontier is empty the diagnostic message now reads *"the starting frontier for this hop is empty — all members were eliminated before reaching it. Check the compatibility (Stage 3a) filters or the previous hop's target_class."* instead of misleadingly blaming the predicate URI.
- `tests/test_cohort_builder.py` — 2 new tests: `test_data_with_ontology_form_predicate_is_indexed_correctly`, `test_trace_shows_nonzero_raw_for_ontology_form_predicate`.

### Fix 2: cross-namespace predicate — local-name alias fallback

`_to_data_uri` can only bridge `#` ↔ `/` within the **same** base namespace. When the domain's object property URIs live in a completely different namespace (e.g. inherited shared namespace `ontobricks.com/ontology#`) the first fix was not sufficient.

**Changes:**

- `src/back/core/graph_analysis/CohortBuilder.py`:
  - `_predicate_alias_map()` — scans loaded triples, builds `{local_name → canonical_data_namespace_uri}`, cached in `self._cache["predicate_alias"]` and invalidated on triple reload.
  - `_resolve_predicate(uri)` — tries `_to_data_uri` first; if the URI is unchanged (foreign namespace) falls back to the alias map by local name.
  - `_normalized_links` and `_normalized_compat` updated to use `_resolve_predicate` instead of `_to_data_uri`.
- `tests/test_cohort_builder.py` — 1 new test: `test_via_from_foreign_namespace_resolved_by_local_name` (exact replica of the `ElectricitySuspended` / `Cust360Auto` production scenario).

---

## Cohort Designer — UX

### Attribute dropdowns scoped to entity

Property dropdowns in the Path "where" filter and the Compatibility section previously listed every property in the ontology regardless of the entity in scope. Users had to scroll through unrelated properties when filtering a specific hop.

**Changes:**

- `src/front/static/query/js/query-cohorts.js`:
  - New `_dataPropsForClass(classUri)` helper — filters to data properties whose `domain` matches the class, with a full-list fallback when ontology metadata is incomplete.
  - `_renderHopWhereRow` now calls `_dataPropsForClass(targetClassUri)`.
  - `_renderCompat` now calls `_dataPropsForClass(this.rule.class_uri)`.

---

## Modified files

| File | Change |
|------|--------|
| `src/back/core/graph_analysis/CohortBuilder.py` | Predicate normalisation fixes + alias map |
| `src/front/static/query/js/query-cohorts.js` | Diagnostic guard + scoped attribute dropdowns |
| `tests/test_cohort_builder.py` | 3 new regression tests |

---

## Upgrade notes

No schema, API, or configuration changes. Drop-in replacement for v3.3.0.
If a cohort was returning empty results due to the `hasClaim` predicate mismatch, re-run **Materialise** — no manual data migration required.
