### PR TITLE
Fix/0.3.1 infinite recursion in DatabricksAuth on startup

### DIFF
--- a/src/back/core/databricks/DatabricksAuth.py
+++ b/src/back/core/databricks/DatabricksAuth.py
@@ -34,6 +34,7 @@ class DatabricksAuth:
 
     # Class-level cache: { (host, warehouse_id): (capable, reason, ts) }
     _cloud_fetch_cache: Dict[Tuple[str, str], Tuple[bool, str, float]] = {}
+    _resolving_cloud_fetch: bool = False
 
     @staticmethod
     def is_databricks_app() -> bool:
@@ -56,6 +57,9 @@ class DatabricksAuth:
     @staticmethod
     def _resolve_global_cloud_fetch_default(host: str, token: str) -> bool:
         """Best-effort load of global CloudFetch setting (default: enabled)."""
+        if DatabricksAuth._resolving_cloud_fetch:
+            return True
+        DatabricksAuth._resolving_cloud_fetch = True
         try:
             from shared.config.settings import get_settings
             from back.objects.registry import RegistryCfg
@@ -74,6 +78,8 @@ class DatabricksAuth:
                 exc,
             )
             return True
+        finally:
+            DatabricksAuth._resolving_cloud_fetch = False
 
     @staticmethod
     def get_workspace_host() -> str:


### PR DESCRIPTION
Fixes #28

## Solution
Added a class-level recursion guard (`_resolving_cloud_fetch`) to `_resolve_global_cloud_fetch_default()`.

The root cause is a circular instantiation chain — resolving the CloudFetch config requires a registry store, which creates a `VolumeFileService`, which instantiates a new `DatabricksAuth`, which tries to resolve CloudFetch config again.

The guard detects when the method is already on the call stack and returns the default value (`True`) immediately instead of re-entering the loop. The flag is reset in a `finally` block so subsequent top-level calls still resolve normally.

This is a single-threaded code path that only runs during app startup, so a simple boolean guard is sufficient here — no locking needed.
