### PR TITLE
feat (ontology) Precision score

### DIFF
--- a/src/api/routers/internal/ontology.py
+++ b/src/api/routers/internal/ontology.py
@@ -1588,6 +1588,13 @@ async def analyze_pitfalls(
                 for r in result["results"].values()
                 if isinstance(r.get("count"), int)
             )
+
+            # Persist precision score to session so the domain home panel can display it.
+            precision_score = result.get("precision_score")
+            if precision_score is not None:
+                domain.precision_score = precision_score
+                domain.save()
+
             tm.complete_task(
                 task.id,
                 result=result,

--- a/src/back/core/external/pitfalls/PitfallsService.py
+++ b/src/back/core/external/pitfalls/PitfallsService.py
@@ -14,6 +14,59 @@ from back.core.logging import get_logger
 
 logger = get_logger(__name__)
 
+# Severity weights per pitfall: P1.x (Logical) are critical, P4.x (Semantic) are minor.
+_PITFALL_WEIGHTS: Dict[str, int] = {
+    "P1.1": 5, "P1.2": 4, "P1.3": 5,
+    "P2.1": 3, "P2.2": 2, "P2.3": 2, "P2.4": 1, "P2.5": 2, "P2.6": 1,
+    "P3.1": 1, "P3.2": 1, "P3.3": 1,
+    "P4.1": 1, "P4.2": 1, "P4.3": 1, "P4.4": 2, "P4.5": 1, "P4.6": 1, "P4.7": 1,
+}
+_MAX_WEIGHT = sum(_PITFALL_WEIGHTS.values())  # 36
+
+
+def _extract_issue_count(pitfall_id: str, result: Dict[str, Any]) -> int:
+    """Return the primary issue count for a pitfall result dict."""
+    if "count" in result and isinstance(result["count"], int):
+        return result["count"]
+    # P2.5 uses multi_domain_count + multi_range_count
+    if "multi_domain_count" in result or "multi_range_count" in result:
+        return (result.get("multi_domain_count") or 0) + (result.get("multi_range_count") or 0)
+    return 0
+
+
+def compute_precision_score(
+    results: Dict[str, Dict[str, Any]],
+    metadata: Dict[str, Any],
+) -> int:
+    """Compute a 0–100 ontology precision score from pitfall results.
+
+    Critical pitfalls (P1.x) are weighted more heavily than minor ones (P4.x).
+    The weighted penalty is normalized by ontology size (class + property count)
+    so that a small ontology with one issue is not penalised as hard as a large one.
+
+    Returns:
+        Integer score in [0, 100].  100 = no pitfalls found.
+    """
+    size = max(
+        1,
+        (metadata.get("classes") or 0)
+        + (metadata.get("object_properties") or 0)
+        + (metadata.get("datatype_properties") or 0),
+    )
+
+    penalty = 0
+    for pid, weight in _PITFALL_WEIGHTS.items():
+        if pid not in results:
+            continue
+        count = _extract_issue_count(pid, results[pid])
+        # Cap per-pitfall contribution at `size` to prevent one bad pattern
+        # from dominating the score.
+        penalty += weight * min(count, size)
+
+    max_penalty = _MAX_WEIGHT * size
+    score = max(0, round(100 * (1 - penalty / max_penalty)))
+    return score
+
 
 def _group_results_by_category(
     selected_pitfalls: List[str],
@@ -94,11 +147,15 @@ class PitfallsService:
                 _Toolkit.pitfall_taxonomy(),
             )
 
+            meta = toolkit.metadata()
+            precision_score = compute_precision_score(results, meta)
+
             return {
-                "metadata": toolkit.metadata(),
+                "metadata": meta,
                 "selected_pitfalls": list(results.keys()),
                 "results": results,
                 "grouped_results": grouped,
+                "precision_score": precision_score,
             }
         finally:
             import os

--- a/src/back/objects/domain/Domain.py
+++ b/src/back/objects/domain/Domain.py
@@ -175,6 +175,7 @@ class Domain:
                 "table_name": delta.get("table_name", ""),
             },
             "stats": self.get_domain_stats(),
+            "precision_score": self._s.precision_score,
         }
 
     def get_domain_stats(self) -> Dict[str, int]:

--- a/src/back/objects/session/DomainSession.py
+++ b/src/back/objects/session/DomainSession.py
@@ -25,7 +25,7 @@ import hashlib
 import json
 import re
 from datetime import datetime, timezone
-from typing import Dict, Any, List, Tuple
+from typing import Dict, Any, List, Optional, Tuple
 
 from back.core.logging import get_logger
 from shared.config.constants import (
@@ -882,6 +882,16 @@ class DomainSession:
     @ontology_changed.setter
     def ontology_changed(self, value: bool):
         self._data["domain"]["ontology_changed"] = value
+
+    @property
+    def precision_score(self) -> Optional[int]:
+        """Last computed ontology precision score (0–100), or None if not yet analyzed."""
+        val = self._data["domain"].get("precision_score")
+        return int(val) if val is not None else None
+
+    @precision_score.setter
+    def precision_score(self, value: Optional[int]) -> None:
+        self._data["domain"]["precision_score"] = value
 
     @property
     def assignment_changed(self) -> bool:

--- a/src/front/static/domain/js/domain-information.js
+++ b/src/front/static/domain/js/domain-information.js
@@ -5,6 +5,33 @@
 
 let currentDomainFolder = null;
 
+/**
+ * Render the ontology precision score bar in the Global tab.
+ * @param {number|null} score - 0–100 integer, or null/undefined if not yet analyzed.
+ */
+function _renderPrecisionScore(score) {
+    const row   = document.getElementById('domainPrecisionScoreRow');
+    const bar   = document.getElementById('domainPrecisionBar');
+    const label = document.getElementById('domainPrecisionLabel');
+    if (!row || !bar || !label) return;
+
+    if (score === null || score === undefined) return;  // not analyzed yet — keep hidden
+
+    row.classList.remove('d-none');
+
+    const pct = Math.max(0, Math.min(100, score));
+    bar.style.width = pct + '%';
+    bar.setAttribute('aria-valuenow', pct);
+
+    let colour = 'bg-success';
+    if (pct < 50) colour = 'bg-danger';
+    else if (pct < 80) colour = 'bg-warning';
+    bar.className = `progress-bar ${colour}`;
+
+    label.textContent = pct + ' / 100';
+    label.style.color = pct < 50 ? '#dc3545' : pct < 80 ? '#fd7e14' : '#198754';
+}
+
 // Load available LLM endpoints
 async function loadLlmEndpoints() {
     const select = document.getElementById('domainLlmEndpoint');
@@ -337,6 +364,7 @@ document.addEventListener('DOMContentLoaded', async function() {
             if (infoData.info && infoData.info.llm_endpoint) {
                 setSelectedLlmEndpoint(infoData.info.llm_endpoint);
             }
+            _renderPrecisionScore(infoData.precision_score);
         }
 
         // The DT panel reads catalog/schema from the dropdown rendering of

--- a/src/front/static/ontology/js/ontology-pitfalls.js
+++ b/src/front/static/ontology/js/ontology-pitfalls.js
@@ -203,6 +203,43 @@ window.PitfallsModule = (function () {
         poll();
     }
 
+    // ── Circular gauge ────────────────────────────────────────────────────────
+
+    /**
+     * Update the SVG circular gauge in the section header.
+     * r=28, circumference = 2π×28 ≈ 175.93
+     */
+    function _updateGauge(score) {
+        const CIRCUMFERENCE = 175.93;
+        const wrapper = document.getElementById('pitfallsGaugeWrapper');
+        const arc     = document.getElementById('pitfallsGaugeArc');
+        const label   = document.getElementById('pitfallsGaugeLabel');
+
+        if (!wrapper || !arc || !label) return;
+
+        wrapper.classList.remove('d-none');
+
+        const pct = Math.max(0, Math.min(100, score));
+        const offset = CIRCUMFERENCE * (1 - pct / 100);
+
+        arc.setAttribute('stroke-dashoffset', offset.toFixed(2));
+
+        // Colour: green ≥ 80, orange ≥ 50, red < 50
+        let colour = '#198754';   // green
+        if (pct < 50) colour = '#dc3545';       // red
+        else if (pct < 80) colour = '#fd7e14';  // orange
+        arc.setAttribute('stroke', colour);
+
+        label.textContent = pct;
+
+        // Also update inline score badge inside the results banner
+        const scoreVal = document.getElementById('pitfallsScoreValue');
+        if (scoreVal) {
+            scoreVal.textContent = pct;
+            scoreVal.style.color = colour;
+        }
+    }
+
     // ── Render results ────────────────────────────────────────────────────────
 
     function _renderResults(result) {
@@ -216,6 +253,11 @@ window.PitfallsModule = (function () {
         for (const pitfallResult of Object.values(result.results || {})) {
             const count = pitfallResult.count || pitfallResult.multi_domain_count || 0;
             totalIssues += typeof count === 'number' ? count : 0;
+        }
+
+        // Precision score gauge
+        if (result.precision_score !== undefined && result.precision_score !== null) {
+            _updateGauge(result.precision_score);
         }
 
         // Summary banner

--- a/src/front/templates/partials/domain/_domain_information.html
+++ b/src/front/templates/partials/domain/_domain_information.html
@@ -115,7 +115,24 @@
                                        placeholder="Your name or organization" 
                                        value="{{ domain.author or '' }}">
                             </div>
-                            
+                        </div>
+
+                        <!-- Ontology Precision Score (populated by JS from /domain/info) -->
+                        <div id="domainPrecisionScoreRow" class="d-none mt-1 mb-2">
+                            <label class="form-label mb-1">
+                                <i class="bi bi-patch-check me-1"></i> Ontology Precision Score
+                            </label>
+                            <div class="d-flex align-items-center gap-3">
+                                <div class="progress flex-grow-1" style="height:10px" title="Ontology precision score">
+                                    <div id="domainPrecisionBar" class="progress-bar" role="progressbar"
+                                         style="width:0%" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
+                                </div>
+                                <span id="domainPrecisionLabel" class="fw-semibold small" style="min-width:42px"></span>
+                            </div>
+                            <div class="small text-muted mt-1">
+                                <i class="bi bi-info-circle me-1"></i>Last score from the
+                                <strong>Pitfalls</strong> analysis. Run an analysis to refresh.
+                            </div>
                         </div>
                     </div>
 

--- a/src/front/templates/partials/ontology/_pitfalls.html
+++ b/src/front/templates/partials/ontology/_pitfalls.html
@@ -6,9 +6,24 @@
         <h4 class="mb-1"><i class="bi bi-bug me-2"></i>Pitfalls</h4>
         <p class="text-muted mb-0 small">Detect structural, logical, and semantic issues in your ontology (P1.1–P4.7)</p>
     </div>
-    <button class="btn btn-sm btn-primary" id="pitfallsRunBtn">
-        <i class="bi bi-play-fill me-1"></i>Run Analysis
-    </button>
+    <div class="d-flex align-items-center gap-3">
+        <!-- Precision score gauge (hidden until first analysis) -->
+        <div id="pitfallsGaugeWrapper" class="d-none text-center" style="min-width:90px" title="Ontology Precision Score">
+            <svg id="pitfallsGaugeSvg" width="72" height="72" viewBox="0 0 72 72" aria-label="Precision score gauge">
+                <circle cx="36" cy="36" r="28" fill="none" stroke="#e9ecef" stroke-width="8"/>
+                <circle id="pitfallsGaugeArc" cx="36" cy="36" r="28" fill="none"
+                        stroke="#198754" stroke-width="8" stroke-linecap="round"
+                        stroke-dasharray="175.93" stroke-dashoffset="175.93"
+                        transform="rotate(-90 36 36)"/>
+                <text id="pitfallsGaugeLabel" x="36" y="40" text-anchor="middle"
+                      font-size="14" font-weight="700" fill="#212529">—</text>
+            </svg>
+            <div class="small text-muted" style="font-size:.7rem;margin-top:-2px">Precision</div>
+        </div>
+        <button class="btn btn-sm btn-primary" id="pitfallsRunBtn">
+            <i class="bi bi-play-fill me-1"></i>Run Analysis
+        </button>
+    </div>
 </div>
 
 <div class="card h-100">
@@ -86,9 +101,15 @@
                 <div id="pitfallsResults" class="d-none">
                     <div class="alert d-flex align-items-center gap-3 mb-3" id="pitfallsSummaryBanner">
                         <i class="bi fs-4" id="pitfallsSummaryIcon"></i>
-                        <div>
+                        <div class="flex-grow-1">
                             <div class="fw-semibold" id="pitfallsSummaryTitle"></div>
                             <div class="small text-muted" id="pitfallsSummaryDetail"></div>
+                        </div>
+                        <!-- Inline precision score badge in result banner -->
+                        <div id="pitfallsScoreBadge" class="text-center" style="min-width:64px">
+                            <div id="pitfallsScoreValue" class="fw-bold fs-4"></div>
+                            <div class="small text-muted" style="font-size:.7rem">/ 100</div>
+                            <div class="small text-muted" style="font-size:.65rem">Precision</div>
                         </div>
                     </div>
                     <div class="accordion" id="pitfallsAccordion"></div>


### PR DESCRIPTION
Add an ontology precision score computed from the existing pitfalls analysis in OntoBricks.
The pitfalls engine is in src/back/core/external/pitfalls/runner.py
(OntologyPatternToolkit) and src/back/objects/domain/PitfallsService.py.
The UI is src/front/static/ontology/js/ontology-pitfalls.js.
Compute a 0–100 score from pitfall results: weight Critical (P1.x) issues more heavily
than Minor (P4.x), normalized by ontology size (class + property count).
Expose it in GET /ontology/pitfalls/results/{task_id} as a precision_score field.
Display a circular gauge in the pitfalls UI header alongside the existing issue count.
Store the score in the domain session so it appears on the domain home panel.