### PR TITLE
Fix/v0.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="src/front/static/global/img/ontobricks-icon.svg" alt="OntoBricks Logo" width="120" height="120">
 </p>
 
-<h1 align="center">OntoBricks 0.5.0</h1>
+<h1 align="center">OntoBricks 0.5.1</h1>
 
 <p align="center">
   <strong>Digital Twin Builder for Databricks</strong>

--- a/changelogs/v0.5.1/benoitcayladbx_2026-06-19.log
+++ b/changelogs/v0.5.1/benoitcayladbx_2026-06-19.log
@@ -1,0 +1,44 @@
+## Fix: Interactive Build Does Not Persist last_build to Registry
+
+### Context
+Bug report: on the Validation page, "Submit for Review" was blocked with
+"This version has never been built. Run a Digital Twin build first." even
+after a successful interactive Digital Twin build.
+
+Root cause: `_BuildPipeline._complete_task()` (the shared completion path
+for both interactive UI and external REST builds) never called
+`store.write_version()` to flush `domain.last_build` to the
+`domain_versions.last_build` DB column.  Only the scheduled-build path
+(`scheduler._persist_domain_metadata`) wrote that column.  The
+`ReviewService.submit()` gate reads the column; the Consistency-checks
+panel reads live triple-store state — hence the two indicators
+disagreed.
+
+### Changes
+
+1. `src/back/objects/digitaltwin/_build_pipeline.py`
+   - Added `_BuildPipeline._persist_last_build_to_registry()`: best-effort
+     method that resolves folder/version (same logic as `_record_build_run`),
+     stamps `domain.last_build` when empty (API build path), and calls
+     `RegistryService.from_context().store.write_version()`.
+   - `_complete_task()` now calls `_persist_last_build_to_registry()` after
+     `_record_build_run()`, covering both `build_kind="session"` (interactive
+     UI) and `build_kind="api"` (external REST).
+
+2. `tests/back/core/digitaltwin/test_build_pipeline_units.py`
+   - Added import for `patch` and `RegistryService`.
+   - Added `TestPersistLastBuildToRegistry` (6 tests):
+     - happy path: `write_version` is called with correct folder + version
+     - domain_data carries `last_build` value
+     - API build path: empty `last_build` is stamped before persist
+     - early-return when folder/version cannot be resolved
+     - graceful handling of `write_version` failure (False return)
+     - graceful handling of `RegistryService.from_context` exception
+
+### Modified files
+- src/back/objects/digitaltwin/_build_pipeline.py
+- tests/back/core/digitaltwin/test_build_pipeline_units.py
+
+### Test results
+2484 passed, 15 skipped, 1 pre-existing failure (pyshacl not installed, unrelated)
+All 22 tests in test_build_pipeline_units.py pass.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ontobricks"
-version = "0.5.0"
+version = "0.5.1"
 description = "Ontology Management Tool for Databricks"
 requires-python = ">=3.10"
 dependencies = [

--- a/releases/ReleaseNotes_V0.5.1.md
+++ b/releases/ReleaseNotes_V0.5.1.md
@@ -1,0 +1,115 @@
+# OntoBricks — Release Notes V0.5.1
+
+**Release date:** 2026-06-19
+**Type:** Patch — single bug fix
+**Test status:** 2484 passing, 15 skipped on the unit tier; 6 new regression tests added.
+
+---
+
+## Summary
+
+v0.5.1 is a targeted patch that fixes a blocker introduced with the v0.5.0 review workflow: the **"Submit for Review"** action on the Validation page was permanently blocked even after a successful Digital Twin build, when that build was triggered interactively (via the Build button in the UI or the external REST endpoint `POST /dtwin/build`).
+
+No schema changes. No configuration changes. No migration scripts required for new deploys.
+
+---
+
+## Bug Fixed
+
+### Submit for Review blocked despite a built Digital Twin
+
+**Symptom:** On the Validation page (`/domain/validate`), the banner *"This version has never been built. Run a Digital Twin build first."* appeared and the **Submit for Review** button was disabled — even though the Consistency-checks panel showed a green **"Digital Twin built"** tick.
+
+**Root cause:** The two indicators on the same page read from different sources:
+
+| Indicator | Source |
+|-----------|--------|
+| Consistency-checks "Digital Twin built" ✅ | Live triple-store state (view exists + has triples) |
+| Submit-for-Review gate | `domain_versions.last_build` column in the registry DB |
+
+The interactive build path (`_BuildPipeline._complete_task`) never wrote `domain.last_build` to the `domain_versions` table. Only the **scheduled** build path (`scheduler._persist_domain_metadata`) performed that write. The Submit gate reads the registry column, found it empty, and blocked.
+
+**Fix:** `_BuildPipeline._complete_task()` — the single success exit shared by both the UI build (`build_kind="session"`) and the REST build (`build_kind="api"`) — now calls a new `_persist_last_build_to_registry()` method immediately after recording the build run. This method:
+
+1. Resolves the domain folder and version (same logic already used for build-run tracing).
+2. Stamps `domain.last_build` with the current UTC timestamp when it is empty (API path).
+3. Calls `RegistryService.from_context(domain, settings)._store.write_version(folder, version, domain_data)` to flush the value to `domain_versions.last_build`.
+4. Is **best-effort**: any exception is logged as a warning and never propagates — a registry hiccup cannot break a build that otherwise succeeded.
+
+**File changed:** `src/back/objects/digitaltwin/_build_pipeline.py`
+**Tests added:** `tests/back/core/digitaltwin/test_build_pipeline_units.py::TestPersistLastBuildToRegistry` (6 cases)
+
+---
+
+## Upgrade Notes
+
+### New deploys (v0.5.1 from scratch)
+
+No action required. The fix is code-only; the `domain_versions` schema and `last_build` column are unchanged from v0.5.0.
+
+### Upgrading from v0.5.0
+
+No schema migration needed. However, any domain version that was built interactively while running v0.5.0 will have an empty `domain_versions.last_build` and will still be blocked at Submit for Review after the upgrade.
+
+**Two options to unblock existing affected versions:**
+
+**Option A — Re-run the build (recommended, zero SQL)**
+
+On the Validation page for the affected domain + version, click the **Build** button again. The build re-populates the triple-store (idempotent — full rebuild) and now also writes `last_build` to the registry. Once the build completes, the Submit for Review button becomes available immediately.
+
+**Option B — Direct SQL patch (no rebuild needed)**
+
+If you want to unblock Submit for Review without re-running the build (e.g. the triple-store is already healthy and you do not want to re-build), connect to the registry Lakebase database and run:
+
+```sql
+-- Replace 'your_schema' with your registry schema (e.g. ontobricks_app_demo).
+-- Replace 'supplychain' and '1' with your actual domain folder and version.
+UPDATE your_schema.domain_versions dv
+SET    last_build  = NOW()::text,
+       updated_at  = NOW()
+FROM   your_schema.domains d
+WHERE  dv.domain_id = d.id
+  AND  d.folder     = 'supplychain'   -- domain folder (sanitised name)
+  AND  dv.version   = '1'             -- version string
+  AND  dv.last_build = '';            -- only patch truly empty rows
+```
+
+To patch **all** versions that have a healthy build artifact but a missing `last_build` in one shot:
+
+```sql
+-- Patches every version whose last_build is empty but whose status is not DRAFT
+-- (i.e. it was previously submitted or published via a scheduled build workaround).
+-- Review the SELECT before running the UPDATE.
+SELECT d.folder, dv.version, dv.status, dv.last_build
+FROM   your_schema.domain_versions dv
+JOIN   your_schema.domains         d  ON d.id = dv.domain_id
+WHERE  dv.last_build = '';
+
+-- Once satisfied, run:
+UPDATE your_schema.domain_versions dv
+SET    last_build = NOW()::text,
+       updated_at = NOW()
+FROM   your_schema.domains d
+WHERE  dv.domain_id = d.id
+  AND  dv.last_build = '';
+```
+
+After the SQL update, reload the Validation page — no app restart is needed.
+
+---
+
+## Changes
+
+| Area | File | Change |
+|------|------|--------|
+| Core fix | `src/back/objects/digitaltwin/_build_pipeline.py` | Added `_persist_last_build_to_registry()`; called from `_complete_task()` |
+| Tests | `tests/back/core/digitaltwin/test_build_pipeline_units.py` | Added `TestPersistLastBuildToRegistry` — 6 regression tests |
+
+---
+
+## What is NOT changed
+
+- `domain_versions` schema — no DDL.
+- Scheduled build path — `scheduler._persist_domain_metadata` is untouched and still the authoritative write for scheduled runs.
+- Consistency-checks panel — continues to read live triple-store state (unchanged behaviour).
+- All other v0.5.0 features — fully intact.

--- a/src/back/objects/digitaltwin/_build_pipeline.py
+++ b/src/back/objects/digitaltwin/_build_pipeline.py
@@ -1257,6 +1257,68 @@ class _BuildPipeline:
                 exc,
             )
 
+    def _persist_last_build_to_registry(self) -> None:
+        """Write last_build to the registry domain_versions row.
+
+        The session/UI build path stamps domain.last_build before the build
+        thread starts; the API path does not.  In both cases the timestamp
+        must reach the DB column so ReviewService.submit() can unblock the
+        Submit-for-Review gate.  Best-effort: a failure is logged but never
+        propagates.
+        """
+        try:
+            from back.objects.registry.RegistryService import RegistryService
+            from back.objects.session import sanitize_domain_folder
+
+            folder = getattr(self.domain, "uc_domain_folder", "") or (
+                sanitize_domain_folder(self.domain_name)
+            )
+            version = (
+                getattr(self.domain_snap, "current_version", None)
+                or getattr(self.domain, "current_version", None)
+                or ""
+            )
+            if not folder or not version:
+                logger.warning(
+                    "[DT-BUILD %s] _persist_last_build_to_registry: "
+                    "cannot resolve folder=%r version=%r — skipping",
+                    self.task_id,
+                    folder,
+                    version,
+                )
+                return
+
+            # API build path never stamps last_build before starting; do it now.
+            if not getattr(self.domain, "last_build", None):
+                self.domain.last_build = datetime.now(timezone.utc).isoformat()
+
+            svc = RegistryService.from_context(self.domain, self.settings)
+            domain_data = self.domain.export_for_save()
+            w_ok, w_msg = svc._store.write_version(folder, version, domain_data)
+            if w_ok:
+                logger.info(
+                    "[DT-BUILD %s] persisted last_build=%s to registry "
+                    "(folder=%s version=%s)",
+                    self.task_id,
+                    self.domain.last_build,
+                    folder,
+                    version,
+                )
+            else:
+                logger.error(
+                    "[DT-BUILD %s] write_version failed when persisting "
+                    "last_build: %s",
+                    self.task_id,
+                    w_msg,
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "[DT-BUILD %s] could not persist last_build to registry "
+                "(non-fatal — Submit for Review gate may remain blocked): %s",
+                self.task_id,
+                exc,
+            )
+
     def _complete_task(self) -> None:
         duration = time.time() - self.start_time
         logger.info(
@@ -1284,6 +1346,7 @@ class _BuildPipeline:
         msg = f"Full rebuild: {self.triple_count} triples in {duration:.1f}s"
         self.tm.complete_task(self.task_id, result=result_data, message=msg)
         self._record_build_run("success", message=msg)
+        self._persist_last_build_to_registry()
 
     def _fail_unexpected(self, exc: Exception) -> None:
         duration = time.time() - self.start_time

--- a/tests/back/core/digitaltwin/test_build_pipeline_units.py
+++ b/tests/back/core/digitaltwin/test_build_pipeline_units.py
@@ -10,6 +10,8 @@ This file covers the **pure** surface:
 - `__init__` derived state (`is_api`, `domain_name`, `parts`,
   `phase_times` initialization, lazy-state defaults).
 - `_log_phase` — records elapsed time on `self.phase_times` and logs.
+- `_persist_last_build_to_registry` — registry write after a successful
+  build so the Submit-for-Review gate is unblocked.
 
 Behaviour-rich phases (the various ``_apply_*`` and ``_*_progress``
 methods) are exercised end-to-end in higher tiers.
@@ -20,11 +22,12 @@ from __future__ import annotations
 import time
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from back.objects.digitaltwin._build_pipeline import _BuildPipeline
+from back.objects.registry.RegistryService import RegistryService
 
 
 def _make_pipeline(**overrides: Any) -> _BuildPipeline:
@@ -175,3 +178,127 @@ class TestLogPhase:
         pipe._log_phase("apply", now - 0.1)
         second = pipe.phase_times["apply"]
         assert second < first  # The retry was faster than the first attempt.
+
+
+# --- _persist_last_build_to_registry ------------------------------------
+
+
+def _make_domain(
+    *,
+    last_build: str = "2026-06-19T09:00:00+00:00",
+    current_version: str = "1",
+    uc_domain_folder: str = "supplychain",
+    name: str = "supplychain",
+) -> SimpleNamespace:
+    """Create a minimal domain stand-in for persist tests."""
+    return SimpleNamespace(
+        info={"name": name},
+        last_build=last_build,
+        current_version=current_version,
+        uc_domain_folder=uc_domain_folder,
+        export_for_save=lambda: {"info": {"last_build": last_build}},
+    )
+
+
+def _make_registry_svc(write_ok: bool = True, write_msg: str = "") -> MagicMock:
+    """Return a mock RegistryService whose _store.write_version returns (write_ok, write_msg)."""
+    svc = MagicMock()
+    svc._store.write_version.return_value = (write_ok, write_msg)
+    return svc
+
+
+@pytest.mark.unit
+class TestPersistLastBuildToRegistry:
+    """_persist_last_build_to_registry writes domain.last_build to the registry DB."""
+
+    def _make_pipe(self, domain=None, **overrides):
+        dom = domain or _make_domain()
+        snap = MagicMock()
+        snap.current_version = dom.current_version
+        return _make_pipeline(domain=dom, domain_snap=snap, **overrides)
+
+    def test_calls_write_version_on_success(self) -> None:
+        """Happy path: write_version is called once with folder + version."""
+        pipe = self._make_pipe()
+        svc = _make_registry_svc()
+
+        with patch.object(RegistryService, "from_context", return_value=svc):
+            pipe._persist_last_build_to_registry()
+
+        svc._store.write_version.assert_called_once()
+        call_args = svc._store.write_version.call_args
+        folder, version, _ = call_args.args
+        assert folder == "supplychain"
+        assert version == "1"
+
+    def test_domain_data_includes_last_build(self) -> None:
+        """The domain_data passed to write_version carries last_build."""
+        pipe = self._make_pipe()
+        svc = _make_registry_svc()
+
+        with patch.object(RegistryService, "from_context", return_value=svc):
+            pipe._persist_last_build_to_registry()
+
+        _, _, domain_data = svc._store.write_version.call_args.args
+        assert domain_data["info"]["last_build"] == "2026-06-19T09:00:00+00:00"
+
+    def test_api_build_stamps_last_build_when_empty(self) -> None:
+        """API build path: domain.last_build is empty before the build; the method
+        stamps it so the registry write carries a non-empty timestamp."""
+        dom = _make_domain(last_build="")
+        snap = MagicMock()
+        snap.current_version = dom.current_version
+        # export_for_save must reflect the updated last_build after stamping.
+        def _export():
+            return {"info": {"last_build": dom.last_build}}
+        dom.export_for_save = _export
+
+        pipe = _make_pipeline(domain=dom, domain_snap=snap, build_kind="api")
+        svc = _make_registry_svc()
+
+        with patch.object(RegistryService, "from_context", return_value=svc):
+            pipe._persist_last_build_to_registry()
+
+        assert dom.last_build  # was stamped
+        _, _, domain_data = svc._store.write_version.call_args.args
+        assert domain_data["info"]["last_build"]
+
+    def test_skips_when_folder_cannot_be_resolved(self) -> None:
+        """No folder available → method returns early without calling write_version."""
+        snap = MagicMock()
+        snap.current_version = ""
+        pipe = _make_pipeline(domain=SimpleNamespace(
+            info={},  # name not set → sanitize_domain_folder returns ""
+            last_build="ts",
+            current_version="",
+            uc_domain_folder="",
+            export_for_save=lambda: {},
+        ), domain_snap=snap)
+        svc = _make_registry_svc()
+
+        with (
+            patch.object(RegistryService, "from_context", return_value=svc),
+            patch("back.objects.session.sanitize_domain_folder", return_value=""),
+        ):
+            pipe._persist_last_build_to_registry()
+
+        svc._store.write_version.assert_not_called()
+
+    def test_handles_write_version_failure_gracefully(self) -> None:
+        """write_version returning (False, msg) is logged but does not raise."""
+        pipe = self._make_pipe()
+        svc = _make_registry_svc(write_ok=False, write_msg="DB error")
+
+        with patch.object(RegistryService, "from_context", return_value=svc):
+            pipe._persist_last_build_to_registry()  # must not raise
+
+        svc._store.write_version.assert_called_once()
+
+    def test_handles_registry_service_exception_gracefully(self) -> None:
+        """An exception from RegistryService.from_context must not propagate."""
+        pipe = self._make_pipe()
+
+        with patch.object(
+            RegistryService, "from_context", side_effect=RuntimeError("connection refused")
+        ):
+            pipe._persist_last_build_to_registry()  # must not raise


### PR DESCRIPTION
# OntoBricks — Release Notes V0.5.1

**Release date:** 2026-06-19
**Type:** Patch — single bug fix
**Test status:** 2484 passing, 15 skipped on the unit tier; 6 new regression tests added.

---

## Summary

v0.5.1 is a targeted patch that fixes a blocker introduced with the v0.5.0 review workflow: the **"Submit for Review"** action on the Validation page was permanently blocked even after a successful Digital Twin build, when that build was triggered interactively (via the Build button in the UI or the external REST endpoint `POST /dtwin/build`).

No schema changes. No configuration changes. No migration scripts required for new deploys.

---

## Bug Fixed

### Submit for Review blocked despite a built Digital Twin

**Symptom:** On the Validation page (`/domain/validate`), the banner *"This version has never been built. Run a Digital Twin build first."* appeared and the **Submit for Review** button was disabled — even though the Consistency-checks panel showed a green **"Digital Twin built"** tick.

**Root cause:** The two indicators on the same page read from different sources:

| Indicator | Source |
|-----------|--------|
| Consistency-checks "Digital Twin built" ✅ | Live triple-store state (view exists + has triples) |
| Submit-for-Review gate | `domain_versions.last_build` column in the registry DB |

The interactive build path (`_BuildPipeline._complete_task`) never wrote `domain.last_build` to the `domain_versions` table. Only the **scheduled** build path (`scheduler._persist_domain_metadata`) performed that write. The Submit gate reads the registry column, found it empty, and blocked.

**Fix:** `_BuildPipeline._complete_task()` — the single success exit shared by both the UI build (`build_kind="session"`) and the REST build (`build_kind="api"`) — now calls a new `_persist_last_build_to_registry()` method immediately after recording the build run. This method:

1. Resolves the domain folder and version (same logic already used for build-run tracing).
2. Stamps `domain.last_build` with the current UTC timestamp when it is empty (API path).
3. Calls `RegistryService.from_context(domain, settings)._store.write_version(folder, version, domain_data)` to flush the value to `domain_versions.last_build`.
4. Is **best-effort**: any exception is logged as a warning and never propagates — a registry hiccup cannot break a build that otherwise succeeded.

**File changed:** `src/back/objects/digitaltwin/_build_pipeline.py`
**Tests added:** `tests/back/core/digitaltwin/test_build_pipeline_units.py::TestPersistLastBuildToRegistry` (6 cases)

---

## Upgrade Notes

### New deploys (v0.5.1 from scratch)

No action required. The fix is code-only; the `domain_versions` schema and `last_build` column are unchanged from v0.5.0.

### Upgrading from v0.5.0

No schema migration needed. However, any domain version that was built interactively while running v0.5.0 will have an empty `domain_versions.last_build` and will still be blocked at Submit for Review after the upgrade.

**Two options to unblock existing affected versions:**

**Option A — Re-run the build (recommended, zero SQL)**

On the Validation page for the affected domain + version, click the **Build** button again. The build re-populates the triple-store (idempotent — full rebuild) and now also writes `last_build` to the registry. Once the build completes, the Submit for Review button becomes available immediately.

**Option B — Direct SQL patch (no rebuild needed)**

If you want to unblock Submit for Review without re-running the build (e.g. the triple-store is already healthy and you do not want to re-build), connect to the registry Lakebase database and run:

```sql
-- Replace 'your_schema' with your registry schema (e.g. ontobricks_app_demo).
-- Replace 'supplychain' and '1' with your actual domain folder and version.
UPDATE your_schema.domain_versions dv
SET    last_build  = NOW()::text,
       updated_at  = NOW()
FROM   your_schema.domains d
WHERE  dv.domain_id = d.id
  AND  d.folder     = 'supplychain'   -- domain folder (sanitised name)
  AND  dv.version   = '1'             -- version string
  AND  dv.last_build = '';            -- only patch truly empty rows
```

To patch **all** versions that have a healthy build artifact but a missing `last_build` in one shot:

```sql
-- Patches every version whose last_build is empty but whose status is not DRAFT
-- (i.e. it was previously submitted or published via a scheduled build workaround).
-- Review the SELECT before running the UPDATE.
SELECT d.folder, dv.version, dv.status, dv.last_build
FROM   your_schema.domain_versions dv
JOIN   your_schema.domains         d  ON d.id = dv.domain_id
WHERE  dv.last_build = '';

-- Once satisfied, run:
UPDATE your_schema.domain_versions dv
SET    last_build = NOW()::text,
       updated_at = NOW()
FROM   your_schema.domains d
WHERE  dv.domain_id = d.id
  AND  dv.last_build = '';
```

After the SQL update, reload the Validation page — no app restart is needed.

---

## Changes

| Area | File | Change |
|------|------|--------|
| Core fix | `src/back/objects/digitaltwin/_build_pipeline.py` | Added `_persist_last_build_to_registry()`; called from `_complete_task()` |
| Tests | `tests/back/core/digitaltwin/test_build_pipeline_units.py` | Added `TestPersistLastBuildToRegistry` — 6 regression tests |

---

## What is NOT changed

- `domain_versions` schema — no DDL.
- Scheduled build path — `scheduler._persist_domain_metadata` is untouched and still the authoritative write for scheduled runs.
- Consistency-checks panel — continues to read live triple-store state (unchanged behaviour).
- All other v0.5.0 features — fully intact.
