### PR TITLE
docs(contributors): use full name for Hugues Journeau in contributors table

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,7 +8,7 @@ Thank you to everyone who has contributed to OntoBricks!
 |------|--------|------|
 | Benoit Cayla | [@benoitcayladbx](https://github.com/benoitcayladbx) | Creator & Lead Maintainer |
 | Dermot Smyth | [@dermotsmyth-db](https://github.com/dermotsmyth-db) | Contributor |
-| hourdays | [@hourdays](https://github.com/hourdays) | Contributor |
+| Hugues Journeau | [@hourdays](https://github.com/hourdays) | Contributor |
 
 ## How to Contribute
 

--- a/changelogs/v0.6.0/hourdays_2026-06-22.log
+++ b/changelogs/v0.6.0/hourdays_2026-06-22.log
@@ -1,0 +1,11 @@
+## List Hugues Journeau by full name in CONTRIBUTORS.md
+
+**Context:** The contributor table in `CONTRIBUTORS.md` lists Benoit Cayla and Dermot Smyth with their full names in the **Name** column, but the third row used the GitHub handle `hourdays` instead of the contributor's full name. Aligns the table for consistency.
+
+**Changes:**
+1. `CONTRIBUTORS.md` — row 3, `Name` column: `hourdays` → `Hugues Journeau` (GitHub handle column unchanged).
+
+**Modified files:**
+- `CONTRIBUTORS.md`
+
+**Test result:** N/A — documentation-only change.


### PR DESCRIPTION
## Summary

Tiny consistency fix in `CONTRIBUTORS.md`: the third row of the contributor table used the GitHub handle `hourdays` in the **Name** column instead of the contributor's full name, while the other two rows use full names.

## Diff

```diff
-| hourdays        | [@hourdays](https://github.com/hourdays) | Contributor |
+| Hugues Journeau | [@hourdays](https://github.com/hourdays) | Contributor |
```

GitHub handle column unchanged.

## Test plan

- [x] Documentation-only change — no tests required.
- [x] Changelog appended under `changelogs/v0.6.0/hourdays_2026-06-22.log` per project convention.