### PR TITLE
feat(mapping): Serialize R2RML in deterministic order

### DIFF
--- a/src/back/core/w3c/r2rml/R2RMLGenerator.py
+++ b/src/back/core/w3c/r2rml/R2RMLGenerator.py
@@ -239,7 +239,7 @@ class R2RMLGenerator:
         g.add((triples_map, RDFS.comment, Literal(comment)))
 
         # Logical Table - using SQL query or table name
-        logical_table = BNode()
+        logical_table = BNode(f"lt_{map_name}")
         g.add((triples_map, self.rr.logicalTable, logical_table))
 
         if sql_query:
@@ -256,7 +256,7 @@ class R2RMLGenerator:
             )
 
         # Subject Map
-        subject_map = BNode()
+        subject_map = BNode(f"sm_{map_name}")
         g.add((triples_map, self.rr.subjectMap, subject_map))
 
         # Template for subject URI - ALWAYS use taxonomy base URI.
@@ -286,11 +286,11 @@ class R2RMLGenerator:
 
         # Add label column mapping if specified
         if label_column:
-            pom = BNode()
+            pom = BNode(f"pom_{map_name}_label")
             g.add((triples_map, self.rr.predicateObjectMap, pom))
             g.add((pom, self.rr.predicate, RDFS.label))
 
-            obj_map = BNode()
+            obj_map = BNode(f"om_{map_name}_label")
             g.add((pom, self.rr.objectMap, obj_map))
             g.add((obj_map, self.rr.column, Literal(label_column)))
 
@@ -299,11 +299,11 @@ class R2RMLGenerator:
 
         # Add attribute mappings (DatatypeProperty mappings)
         if attribute_mappings:
-            for attr_name, column_name in attribute_mappings.items():
+            for attr_name, column_name in sorted(attribute_mappings.items()):
                 if not column_name:
                     continue
 
-                pom = BNode()
+                pom = BNode(f"pom_{map_name}_{self._sanitize_name(attr_name)}")
                 g.add((triples_map, self.rr.predicateObjectMap, pom))
 
                 # Prefer the ontology property URI when it matches the
@@ -320,7 +320,7 @@ class R2RMLGenerator:
                     )
                 g.add((pom, self.rr.predicate, attr_uri))
 
-                obj_map = BNode()
+                obj_map = BNode(f"om_{map_name}_{self._sanitize_name(attr_name)}")
                 g.add((pom, self.rr.objectMap, obj_map))
                 g.add((obj_map, self.rr.column, Literal(column_name)))
                 g.add((obj_map, self.rr.datatype, XSD.string))  # Default to string
@@ -445,7 +445,7 @@ class R2RMLGenerator:
         )
 
         # Logical Table - using SQL query if provided
-        logical_table = BNode()
+        logical_table = BNode(f"lt_{map_name}")
         g.add((triples_map, self.rr.logicalTable, logical_table))
 
         if sql_query:
@@ -468,7 +468,7 @@ class R2RMLGenerator:
                     )
 
         # Subject Map - references the source entity
-        subject_map = BNode()
+        subject_map = BNode(f"sm_{map_name}")
         g.add((triples_map, self.rr.subjectMap, subject_map))
 
         source_class_name = self._resolve_class_name(
@@ -489,7 +489,7 @@ class R2RMLGenerator:
         )
 
         # Predicate Object Map
-        pom = BNode()
+        pom = BNode(f"pom_{map_name}")
         g.add((triples_map, self.rr.predicateObjectMap, pom))
 
         # Predicate Map - the relationship property.
@@ -511,7 +511,7 @@ class R2RMLGenerator:
             g.add((pom, self.rr.predicate, URIRef(f"{self.base_uri}{property_uri}")))
 
         # Object Map - reference to target entity
-        obj_map = BNode()
+        obj_map = BNode(f"om_{map_name}")
         g.add((pom, self.rr.objectMap, obj_map))
 
         target_class_name = self._resolve_class_name(

--- a/tests/units/mapping/test_r2rml_generator.py
+++ b/tests/units/mapping/test_r2rml_generator.py
@@ -249,3 +249,75 @@ class TestConvenienceFunction:
         ontology = {"base_uri": "http://example.org/"}
         r2rml = generate_r2rml_from_config(mapping, ontology)
         assert r2rml is not None
+
+
+class TestDeterministicSerialization:
+    """R2RML output must be byte-for-byte identical across repeated calls."""
+
+    _MAPPING = {
+        "entities": [
+            {
+                "ontology_class": "http://test.org/ontology/Customer",
+                "ontology_class_label": "Customer",
+                "sql_query": "SELECT id, name, email FROM customers",
+                "id_column": "id",
+                "label_column": "name",
+                "attribute_mappings": {"email": "email", "age": "age"},
+            },
+            {
+                "ontology_class": "http://test.org/ontology/Contract",
+                "ontology_class_label": "Contract",
+                "sql_query": "SELECT id, title FROM contracts",
+                "id_column": "id",
+                "attribute_mappings": {"title": "title"},
+            },
+        ],
+        "relationships": [
+            {
+                "property": "http://test.org/ontology/hasContract",
+                "property_label": "hasContract",
+                "source_class": "http://test.org/ontology/Customer",
+                "source_class_label": "Customer",
+                "target_class": "http://test.org/ontology/Contract",
+                "target_class_label": "Contract",
+                "source_id_column": "customer_id",
+                "target_id_column": "contract_id",
+                "sql_query": "SELECT customer_id, contract_id FROM customer_contracts",
+            }
+        ],
+    }
+
+    def test_repeated_calls_produce_identical_output(self):
+        gen = R2RMLGenerator("http://test.org/ontology/")
+        first = gen.generate_mapping(self._MAPPING)
+        second = gen.generate_mapping(self._MAPPING)
+        assert first == second
+
+    def test_attribute_order_is_stable(self):
+        """Attributes in reverse-alphabetical input order must still sort consistently."""
+        gen = R2RMLGenerator("http://test.org/ontology/")
+        mapping_z_first = {
+            "entities": [
+                {
+                    "ontology_class": "http://test.org/ontology/Item",
+                    "ontology_class_label": "Item",
+                    "sql_query": "SELECT * FROM items",
+                    "id_column": "id",
+                    "attribute_mappings": {"zzz": "col_z", "aaa": "col_a"},
+                }
+            ],
+            "relationships": [],
+        }
+        mapping_a_first = {
+            "entities": [
+                {
+                    "ontology_class": "http://test.org/ontology/Item",
+                    "ontology_class_label": "Item",
+                    "sql_query": "SELECT * FROM items",
+                    "id_column": "id",
+                    "attribute_mappings": {"aaa": "col_a", "zzz": "col_z"},
+                }
+            ],
+            "relationships": [],
+        }
+        assert gen.generate_mapping(mapping_z_first) == gen.generate_mapping(mapping_a_first)


### PR DESCRIPTION
## Summary

`BNode()` in rdflib generates a random UUID-based identifier when called with no argument. With ten blank nodes per mapping document, regenerating R2RML for an unchanged mapping produced a completely different Turtle file every time, making `git diff` unreadable. A secondary source of non-determinism was the unsorted iteration of `attribute_mappings`. Both are fixed by binding blank-node IDs to a stable string derived from the class/property name and emitting attributes in sorted order.

## Linked Issue / milestone

Closes #51 

## Plan

N/A — single-file logic fix, no design decisions required.

## Type of change

- [x] feat — new feature

## Author checklist

- [x] Conventional Commit PR title (`<type>(<scope>): <subject>`).
- [ ] `changelogs/<today>.log` updated with title + context + numbered changes + files + test result.
- [x] Tests added or modified for every behaviour change.
- [ ] `uv run pytest tests/<scope>/` green locally.
- [ ] `pre-commit run --all-files` clean (or skipped hooks documented).

## Test plan

I don't have a working development environment to execute the tests.
Need help from the reviewer to execute the test suite.
I have validated the change by deploying the code and executing R2RML exports through the API endpoints for 5 ontologies successfully.

- [ ] `uv run pytest tests/ -m "not e2e and not property and not eval" --cov-fail-under=90`
- [ ] Per-package coverage thresholds (`scripts/check_coverage.py`) green for touched packages.

## Reviewer hint

See `docs/PR_REVIEW_CHECKLIST.md`. Numbered items map 1:1 to comments — `#3: missing OntoBricksError subclass for new condition` is more useful than "fix error handling".