### PR TITLE
fix(mapping): deduplicate Auto-Map SQL columns colliding with ID/Label alias

### DIFF
--- a/src/agents/tools/mapping.py
+++ b/src/agents/tools/mapping.py
@@ -9,6 +9,7 @@ import re
 from typing import Callable, Dict, List, Optional
 
 from back.core.logging import get_logger
+from back.core.sqlwizard.SQLWizardService import SQLWizardService
 from agents.tools.context import ToolContext
 
 logger = get_logger(__name__)
@@ -53,6 +54,9 @@ def tool_submit_entity_mapping(
         re.sub(r"\s+LIMIT\s+\d+\s*$", "", sql_query, flags=re.IGNORECASE)
         .strip()
         .rstrip(";")
+    )
+    clean_sql = SQLWizardService._deduplicate_select_columns(
+        clean_sql, mapping_type="entity"
     )
 
     # Restrict attribute_mappings to attributes declared in the ontology for this entity.
@@ -180,6 +184,9 @@ def tool_submit_relationship_mapping(
         re.sub(r"\s+LIMIT\s+\d+\s*$", "", sql_query, flags=re.IGNORECASE)
         .strip()
         .rstrip(";")
+    )
+    clean_sql = SQLWizardService._deduplicate_select_columns(
+        clean_sql, mapping_type="relationship"
     )
 
     def _extract_label(value: str) -> str:

--- a/src/back/core/sqlwizard/SQLWizardService.py
+++ b/src/back/core/sqlwizard/SQLWizardService.py
@@ -615,7 +615,8 @@ class SQLWizardService:
         token = col_expr.strip().split(".")[-1].strip('`"')
         return token
 
-    def _deduplicate_select_columns(self, sql: str, mapping_type: str = None) -> str:
+    @staticmethod
+    def _deduplicate_select_columns(sql: str, mapping_type: str = None) -> str:
         """Ensure every column in the SELECT list has a unique output name.
 
         - For *entity* queries: guarantees the first column is aliased AS ID
@@ -624,13 +625,16 @@ class SQLWizardService:
           AS source_id and the second AS target_id.
         - For any query: if two columns share the same effective output name,
           the later occurrence(s) get a numeric suffix (e.g. col_2).
+
+        Made static so it can be reused from agents/tools/mapping.py's Auto-Map
+        submission tools without constructing a full SQLWizardService.
         """
-        parsed = self._parse_select_columns(sql)
+        parsed = SQLWizardService._parse_select_columns(sql)
         if parsed is None or len(parsed) != 3:
             return sql
 
         prefix, select_part, rest = parsed
-        columns = self._split_columns(select_part)
+        columns = SQLWizardService._split_columns(select_part)
 
         if not columns:
             return sql
@@ -646,7 +650,7 @@ class SQLWizardService:
         for idx, alias in required.items():
             if idx < len(columns):
                 col = columns[idx]
-                eff = self._effective_name(col)
+                eff = SQLWizardService._effective_name(col)
                 if eff.upper() != alias.upper():
                     # Strip any existing alias first
                     col_stripped = re.sub(
@@ -658,10 +662,10 @@ class SQLWizardService:
         seen = {}  # lowercase name -> count
         deduped = []
         for col in columns:
-            eff = self._effective_name(col).lower()
+            eff = SQLWizardService._effective_name(col).lower()
             if eff in seen:
                 seen[eff] += 1
-                new_alias = f"{self._effective_name(col)}_{seen[eff]}"
+                new_alias = f"{SQLWizardService._effective_name(col)}_{seen[eff]}"
                 col_stripped = re.sub(
                     r"\s+AS\s+\S+\s*$", "", col, flags=re.IGNORECASE
                 ).strip()

--- a/tests/units/agents/test_mapping_tools.py
+++ b/tests/units/agents/test_mapping_tools.py
@@ -1,0 +1,95 @@
+"""Regression tests for agents/tools/mapping.py's SQL deduplication guard.
+
+Real-world bug: the auto-mapping agent's own prompt instructs it to alias
+the id/label source column (e.g. "AS Label") *and* repeat it under its
+original name for attribute mapping. When that original name is itself
+"id"/"label" (case-insensitive) — e.g. a `gold_segment` table with an
+actual column named `label` — this produces two columns Databricks
+resolves as the same one, and the digital-twin build fails with
+`AMBIGUOUS_REFERENCE` at Sync time. `tool_submit_entity_mapping` /
+`tool_submit_relationship_mapping` must deduplicate before persisting the
+mapping, regardless of what the LLM actually generated.
+"""
+
+import pytest
+
+from agents.tools.context import ToolContext
+from agents.tools.mapping import (
+    tool_submit_entity_mapping,
+    tool_submit_relationship_mapping,
+)
+
+
+@pytest.fixture
+def ctx():
+    return ToolContext(host="https://test.databricks.com", token="fake-token")
+
+
+@pytest.mark.unit
+class TestEntityMappingLabelCollision:
+    def test_label_column_named_label_is_deduplicated(self, ctx):
+        """The exact production shape: label_column="Label" sourced from a
+        physical column literally named "label", also listed as a
+        standalone attribute — the classic self-collision."""
+        sql = (
+            "SELECT segment_id AS ID, label AS Label, segment_id, label, description "
+            "FROM catalog.schema.gold_segment WHERE segment_id IS NOT NULL"
+        )
+        tool_submit_entity_mapping(
+            ctx,
+            class_uri="http://test.org/ontology#Segment",
+            class_name="Segment",
+            sql_query=sql,
+            id_column="ID",
+            label_column="Label",
+            attribute_mappings={"hasLabel": "label", "hasDescription": "description"},
+        )
+        assert len(ctx.entity_mappings) == 1
+        stored_sql = ctx.entity_mappings[0]["sql_query"]
+
+        # The duplicate "label" column must be renamed, not left colliding
+        # with "Label" under case-insensitive resolution.
+        assert "label AS Label" in stored_sql
+        assert ", label," not in stored_sql, f"unresolved duplicate in: {stored_sql}"
+
+    def test_no_collision_when_columns_are_distinct(self, ctx):
+        """Sanity check: distinct column names pass through unchanged."""
+        sql = (
+            "SELECT viewer_id AS ID, display_name AS Label, viewer_id, display_name, region "
+            "FROM catalog.schema.gold_viewer WHERE viewer_id IS NOT NULL"
+        )
+        tool_submit_entity_mapping(
+            ctx,
+            class_uri="http://test.org/ontology#Viewer",
+            class_name="Viewer",
+            sql_query=sql,
+            id_column="ID",
+            label_column="Label",
+            attribute_mappings={"hasRegion": "region"},
+        )
+        stored_sql = ctx.entity_mappings[0]["sql_query"]
+        assert "viewer_id AS ID" in stored_sql
+        assert "display_name AS Label" in stored_sql
+
+
+@pytest.mark.unit
+class TestRelationshipMappingDedup:
+    def test_relationship_columns_are_deduplicated_too(self, ctx):
+        sql = (
+            "SELECT viewer_id AS source_id, segment_id AS target_id "
+            "FROM catalog.schema.gold_viewer WHERE viewer_id IS NOT NULL AND segment_id IS NOT NULL"
+        )
+        tool_submit_relationship_mapping(
+            ctx,
+            property_uri="http://test.org/ontology#belongsTo",
+            property_name="belongsTo",
+            sql_query=sql,
+            source_id_column="source_id",
+            target_id_column="target_id",
+            domain="http://test.org/ontology#Viewer",
+            range_class="http://test.org/ontology#Segment",
+        )
+        assert len(ctx.relationships) == 1
+        stored_sql = ctx.relationships[0]["sql_query"]
+        assert "AS source_id" in stored_sql
+        assert "AS target_id" in stored_sql


### PR DESCRIPTION
## What changed
- Made `SQLWizardService._deduplicate_select_columns` a `@staticmethod` (it only ever used other static helpers on the class, so this was safe) so it can be called without constructing a full `SQLWizardService`.
- Wired that dedup call into `agents/tools/mapping.py`'s `tool_submit_entity_mapping` (with `mapping_type="entity"`) and `tool_submit_relationship_mapping` (with `mapping_type="relationship"`), immediately after the existing LIMIT-stripping step and before the mapping is persisted into `ToolContext`.
- Added `tests/units/agents/test_mapping_tools.py` with regression coverage for the collision case and a sanity check that non-colliding columns pass through unchanged.

## Why
The Auto-Map agent's own prompt instructs it to alias the id/label source column (e.g. `... AS Label`) *and* repeat that same source column under its original name so it can also be mapped as a regular attribute. When the original column name is itself `id`/`label` (case-insensitive) — e.g. a table with a real column literally named `label` — the generated SQL ends up with two columns that Databricks/Spark resolve to the same effective name. This causes `AMBIGUOUS_REFERENCE` when the digital-twin build later creates the triple-store VIEW from this SQL.

`SQLWizardService` already had a `_deduplicate_select_columns` safeguard that handles exactly this, but it was only wired into the manual SQL-wizard flow (`generate_sql` / `validate_sql_static`), not into the Auto-Map agent's submission tools — so mappings produced by Auto-Map could silently carry this bug through to build time.

## How to test
```bash
uv sync
uv run pytest tests/units/agents/test_mapping_tools.py tests/units/core/test_sql_wizard.py -v
uv run pytest -q
```
All tests pass (47/47 targeted, full suite unaffected). Reverting just the two new dedup call sites in `agents/tools/mapping.py` and re-running `test_label_column_named_label_is_deduplicated` reproduces the original bug (assertion fails on an unresolved duplicate `label` column), confirming the fix is necessary.