### PR TITLE
Release v0.6.1 — deploy hardening, Switch fix backport, Auto-Map SQL dedup

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,6 +9,7 @@ Thank you to everyone who has contributed to OntoBricks!
 | Benoit Cayla | [@benoitcayladbx](https://github.com/benoitcayladbx) | Creator & Lead Maintainer |
 | Dermot Smyth | [@dermotsmyth-db](https://github.com/dermotsmyth-db) | Contributor |
 | Hugues Journeau | [@hourdays](https://github.com/hourdays) | Contributor |
+| Eric Poilvet | [@epoilvet](https://github.com/epoilvet) | Contributor |
 
 ## How to Contribute
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ scripts/start.sh
 brew install databricks            # or curl -fsSL https://databricks.com/install.sh | sh
 databricks auth login --host https://<workspace>
 
-# Edit scripts/deploy.config.sh (warehouse, registry catalog/schema,
+# Edit scripts/deploy.config.sh (CLI profile, warehouse, registry catalog/schema,
 # Lakebase project/branch/database — see the file header) and then:
 make deploy
 # Or directly: scripts/deploy.sh

--- a/changelogs/v0.6.1/benoitcayladbx_2026-07-03.log
+++ b/changelogs/v0.6.1/benoitcayladbx_2026-07-03.log
@@ -99,3 +99,35 @@ Modified files:
 - tests/units/scripts/test_lakebase_resolve_db.py
 
 Tests: uv run pytest -q -m "not scenario" → 2990 passed, 275 skipped, 5 deselected in 20.32s
+
+## Backport mapping SQL column deduplication fix (PR #98)
+
+Context: The Auto-Map agent's prompt instructs repeating a source column under its
+original name alongside an "AS ID"/"AS Label" alias for attribute mapping. When that
+original name is itself "id"/"label" (case-insensitive) — e.g. a table with an actual
+column named `label` — Databricks/Spark resolves both as the same output column, causing
+`AMBIGUOUS_REFERENCE` when the digital-twin build creates the triple-store VIEW.
+`SQLWizardService._deduplicate_select_columns` already handled this in the manual
+SQL-wizard flow but not in the Auto-Map submission tools. Cherry-picked from PR #98
+(epoilvet) onto the 0.6.1 release branch.
+
+Changes:
+
+1. src/agents/tools/mapping.py
+   Call `SQLWizardService._deduplicate_select_columns` after LIMIT stripping in
+   `tool_submit_entity_mapping` and `tool_submit_relationship_mapping`.
+2. src/back/core/sqlwizard/SQLWizardService.py
+   Make `_deduplicate_select_columns` a `@staticmethod` so agents can reuse it
+   without constructing a full `SQLWizardService`.
+3. tests/units/agents/test_mapping_tools.py
+   Regression tests for label-column self-collision and non-colliding passthrough.
+4. CONTRIBUTORS.md
+   Add Eric Poilvet ([@epoilvet](https://github.com/epoilvet)) to the contributor list.
+
+Modified files:
+- src/agents/tools/mapping.py
+- src/back/core/sqlwizard/SQLWizardService.py
+- tests/units/agents/test_mapping_tools.py
+- CONTRIBUTORS.md
+
+Tests: uv run pytest -q -m "not scenario" → 2982 passed, 286 skipped, 5 deselected in 38.16s

--- a/changelogs/v0.6.1/benoitcayladbx_2026-07-03.log
+++ b/changelogs/v0.6.1/benoitcayladbx_2026-07-03.log
@@ -24,4 +24,78 @@ Modified files:
 - tests/units/front/test_switch_domain_modal.py
 - docs/user-guide.md
 
-Tests: uv run pytest -q -m "not scenario" → 2987 passed, 275 skipped, 5 deselected in 29.67s
+Tests: uv run pytest -q -m "not scenario" → 2987 passed, 275 skipped, 5 deselected in 26.89s
+
+## Add Databricks CLI profile to deploy.config.sh
+
+Context: Deploy and bootstrap scripts call the Databricks CLI without a way to
+pin a non-default profile from the single source of truth. Users with multiple
+profiles had to export DATABRICKS_CONFIG_PROFILE manually before every make target.
+
+Changes:
+
+1. scripts/deploy.config.sh
+   Added DEFAULT_DATABRICKS_PROFILE (exported as DATABRICKS_CONFIG_PROFILE when set).
+2. scripts/deploy.sh
+   Show the active profile in the deploy summary; auth hints mention --profile when configured.
+3. docs/deployment.md
+   Document DEFAULT_DATABRICKS_PROFILE in the deploy.config.sh variable table.
+4. README.md
+   Mention CLI profile in the deploy.config.sh edit step.
+
+Tests: uv run pytest -q -m "not scenario" → 2987 passed, 275 skipped, 5 deselected in 26.89s
+
+## Lakebase connection diagnostics in deploy scripts
+
+Context: Lakebase misconfiguration errors (wrong project/branch, stale db-… id,
+missing database) were terse. Operators had to guess which CLI commands to run to
+inspect the live Lakebase project.
+
+Changes:
+
+1. scripts/_lakebase-diag.sh (new)
+   Shared helper printing common causes and ready-to-run databricks postgres
+   list-databases / endpoints commands (with --profile when configured).
+2. scripts/deploy.sh
+   Call diagnostics on db-… resolution failure, resource checks, dry-run abort,
+   bootstrap failure, and Lakebase step ERR-trap hints.
+3. scripts/bootstrap-lakebase-perms.sh
+   Call diagnostics on endpoint/credentials/psql connection failures; distinguish
+   psql connection errors from missing schema.
+
+Modified files:
+- scripts/_lakebase-diag.sh
+- scripts/deploy.sh
+- scripts/bootstrap-lakebase-perms.sh
+
+Tests: uv run pytest -q -m "not scenario" → 2987 passed, 275 skipped, 5 deselected in 20.35s
+
+## Lakebase underscore vs hyphen naming (deploy resolver)
+
+Context: Lakebase exposes two names per database — status.postgres_database (PG
+datname, underscores) vs the resource-path database_id (RFC-1123, hyphens only).
+Operators saw ontobricks_demo become ontobricks-demo in list-databases and deploy
+failed on exact string match.
+
+Changes:
+
+1. scripts/_lakebase-resolve-db.py (new)
+   Resolve db segment + datname with underscore/hyphen slug tolerance.
+2. scripts/deploy.sh
+   Use the shared resolver; auto-correct LAKEBASE_DATABASE when slug-matched.
+3. scripts/_lakebase-diag.sh
+   Document the two-name model in failure hints.
+4. scripts/deploy.config.sh
+   Comment that DEFAULT_LAKEBASE_DATABASE must come from postgres_database, not
+   the hyphenated resource id.
+5. tests/units/scripts/test_lakebase_resolve_db.py
+   Regression tests for slug matching.
+
+Modified files:
+- scripts/_lakebase-resolve-db.py
+- scripts/deploy.sh
+- scripts/_lakebase-diag.sh
+- scripts/deploy.config.sh
+- tests/units/scripts/test_lakebase_resolve_db.py
+
+Tests: uv run pytest -q -m "not scenario" → 2990 passed, 275 skipped, 5 deselected in 20.32s

--- a/changelogs/v0.6.1/benoitcayladbx_2026-07-06.log
+++ b/changelogs/v0.6.1/benoitcayladbx_2026-07-06.log
@@ -1,0 +1,18 @@
+## Update product roadmap — Delta Graph DB in v0.7.0
+
+Context: The July 2026 roadmap listed v0.7.0 as Neo4j-only graph engine expansion.
+Delta Lake is today the governance triple store but not a selectable Graph DB engine
+(`GraphDBFactory` ships Lakebase only). The roadmap now plans Delta as a first-class
+Graph DB backend alongside Neo4j in v0.7.0, and records v0.6.1 as the current stable line.
+
+Changes:
+
+1. releases/Roadmap_2026-07.md
+   Executive summary, storage-layer table, v0.6.1 delivered section, v0.7.0 split into
+   Delta Graph DB + Neo4j pillars, feature matrix row, graph engine comparison table,
+   and open question on dual-layer vs Delta-only deployments.
+
+Modified files:
+- releases/Roadmap_2026-07.md
+
+Tests: N/A (documentation-only change)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -431,6 +431,7 @@ Edit the workspace-specific defaults in `scripts/deploy.config.sh`:
 
 | Variable | Maps to | Description |
 |----------|---------|-------------|
+| `DEFAULT_DATABRICKS_PROFILE` | `DATABRICKS_CONFIG_PROFILE` (CLI env) | Databricks CLI profile from `databricks auth profiles`. Empty = CLI default. |
 | `DEFAULT_APP_NAME` | `databricks.yml > var.app_name` and `DATABRICKS_APP_NAME` at runtime | Deployed name of the FastAPI app (e.g. `ontobricks-030`). |
 | `DEFAULT_MCP_APP_NAME` | `databricks.yml > var.mcp_app_name` | Deployed name of the MCP companion (must start with `mcp-`). |
 | `DEFAULT_DAB_TARGET` | `databricks bundle deploy -t <target>` | `dev-lakebase` (default) or `dev` (volume-only fallback). |

--- a/releases/ReleaseNotes_V0.6.1.md
+++ b/releases/ReleaseNotes_V0.6.1.md
@@ -1,0 +1,151 @@
+# OntoBricks — Release Notes V0.6.1
+
+**Release date:** 2026-07-03
+**Type:** Patch release (v0.6.0 → v0.6.1)
+**Test status:** 2990 passed, 275 skipped, 5 deselected (`uv run pytest -q -m "not scenario"`).
+
+---
+
+## Summary
+
+v0.6.1 is a focused patch on top of v0.6.0. It fixes the **Switch** modal on published /
+in-review domains, hardens **Lakebase deploy** diagnostics and database-name resolution,
+adds **Databricks CLI profile** support to deploy scripts, and backports a **mapping SQL
+column deduplication** fix that prevents `AMBIGUOUS_REFERENCE` errors during digital-twin
+builds.
+
+No breaking changes. No schema migrations required.
+
+---
+
+## Highlights
+
+- **Switch modal on read-only versions** — on IN-REVIEW or PUBLISHED domains, the version
+  picker is now usable while the "Save my changes before switching" option is correctly
+  disabled (fixes [#97](https://github.com/databrickslabs/ontobricks/issues/97)).
+- **Lakebase deploy resilience** — shared diagnostics helper, underscore/hyphen slug
+  tolerance when resolving `db-…` resource segments vs Postgres `datname`, and clearer
+  failure hints with ready-to-run CLI commands.
+- **Deploy ergonomics** — `DEFAULT_DATABRICKS_PROFILE` in `scripts/deploy.config.sh`
+  pins the CLI profile for all deploy and bootstrap targets.
+- **Auto-Map SQL fix** — duplicate `id`/`label` column references in agent-submitted
+  mappings are deduplicated before build (backport from PR #98, Eric Poilvet).
+
+---
+
+## Bug Fixes
+
+### Switch modal on published / in-review domains ([#97](https://github.com/databrickslabs/ontobricks/issues/97))
+
+On non-DRAFT lifecycle versions, the L2 **Switch** popup previously kept the version
+dropdown disabled and still offered "Save my changes before switching" even though
+read-only versions cannot be saved.
+
+- `permissions.css` — exempt `#switchVersionSelect` from the read-only select disable rule
+  (navigation, not design editing).
+- `navbar.js` — `isSwitchSaveAllowed()`, `configureSwitchSaveOption()`, and a confirm-handler
+  guard disable save-before-switch on non-DRAFT versions.
+- `docs/user-guide.md` — documents read-only Switch behaviour (version picker available,
+  save option disabled).
+
+### Auto-Map SQL column deduplication (PR #98 backport)
+
+When the Auto-Map agent repeats a source column under its original name alongside an
+"AS ID" / "AS Label" alias, and that original name is itself `id` or `label`
+(case-insensitive), Databricks/Spark resolves both as the same output column, causing
+`AMBIGUOUS_REFERENCE` when the digital-twin build creates the triple-store VIEW.
+
+- `src/agents/tools/mapping.py` — call `SQLWizardService._deduplicate_select_columns`
+  after LIMIT stripping in `tool_submit_entity_mapping` and
+  `tool_submit_relationship_mapping`.
+- `src/back/core/sqlwizard/SQLWizardService.py` — `_deduplicate_select_columns` is now a
+  `@staticmethod` so agents can reuse it without constructing a full service instance.
+- `CONTRIBUTORS.md` — Eric Poilvet ([@epoilvet](https://github.com/epoilvet)) added.
+
+---
+
+## Deploy & Operations
+
+### Databricks CLI profile (`deploy.config.sh`)
+
+Deploy and bootstrap scripts now honour a single source of truth for the CLI profile.
+Users with multiple Databricks profiles no longer need to export
+`DATABRICKS_CONFIG_PROFILE` manually before every `make` target.
+
+- `scripts/deploy.config.sh` — `DEFAULT_DATABRICKS_PROFILE` (exported as
+  `DATABRICKS_CONFIG_PROFILE` when set).
+- `scripts/deploy.sh` — active profile shown in the deploy summary; auth hints mention
+  `--profile` when configured.
+- `docs/deployment.md` and `README.md` — document the new variable.
+
+### Lakebase connection diagnostics
+
+Lakebase misconfiguration errors (wrong project/branch, stale `db-…` id, missing
+database) now print actionable hints instead of terse failures.
+
+- `scripts/_lakebase-diag.sh` (new) — shared helper printing common causes and
+  ready-to-run `databricks postgres list-databases` / `endpoints` commands (with
+  `--profile` when configured).
+- `scripts/deploy.sh` — diagnostics on `db-…` resolution failure, resource checks,
+  dry-run abort, bootstrap failure, and Lakebase step ERR-trap hints.
+- `scripts/bootstrap-lakebase-perms.sh` — diagnostics on endpoint/credentials/psql
+  connection failures; distinguishes psql connection errors from missing schema.
+
+### Lakebase underscore vs hyphen naming
+
+Lakebase exposes two names per database — `status.postgres_database` (PG `datname`,
+underscores) vs the resource-path `database_id` (RFC-1123, hyphens only). Operators
+saw `ontobricks_demo` become `ontobricks-demo` in `list-databases` and deploy failed on
+exact string match.
+
+- `scripts/_lakebase-resolve-db.py` (new) — resolve `db` segment + `datname` with
+  underscore/hyphen slug tolerance.
+- `scripts/deploy.sh` — uses the shared resolver; auto-corrects `LAKEBASE_DATABASE` when
+  slug-matched.
+- `scripts/_lakebase-diag.sh` — documents the two-name model in failure hints.
+- `scripts/deploy.config.sh` — comment that `DEFAULT_LAKEBASE_DATABASE` must come from
+  `postgres_database`, not the hyphenated resource id.
+
+---
+
+## Upgrade Notes
+
+### Upgrading from v0.6.0
+
+No schema changes. Deploy the new app bundle as usual (`make deploy`). If you use a
+non-default Databricks CLI profile, set `DEFAULT_DATABRICKS_PROFILE` in
+`scripts/deploy.config.sh` once instead of exporting it per session.
+
+If Lakebase deploy previously failed because your configured database name used
+underscores while the API returned hyphens (or vice versa), v0.6.1 should resolve the
+mismatch automatically. Ensure `DEFAULT_LAKEBASE_DATABASE` in `deploy.config.sh` matches
+the Postgres `postgres_database` field from `databricks postgres list-databases`, not the
+hyphenated resource-path tail.
+
+### Upgrading from v0.5.x
+
+Upgrade to v0.6.0 first (see `releases/ReleaseNotes_V0.6.0.md` for migration steps),
+then apply v0.6.1 on top.
+
+---
+
+## Changes Summary
+
+| Area | Key files | Change type |
+|------|-----------|-------------|
+| Switch modal (read-only versions) | `permissions.css`, `navbar.js`, `test_switch_domain_modal.py`, `docs/user-guide.md` | Fix |
+| Auto-Map SQL deduplication | `agents/tools/mapping.py`, `SQLWizardService.py`, `test_mapping_tools.py` | Fix |
+| CLI profile support | `deploy.config.sh`, `deploy.sh`, `docs/deployment.md`, `README.md` | Enhancement |
+| Lakebase diagnostics | `_lakebase-diag.sh`, `deploy.sh`, `bootstrap-lakebase-perms.sh` | Enhancement |
+| Lakebase name resolver | `_lakebase-resolve-db.py`, `deploy.sh`, `test_lakebase_resolve_db.py` | Fix |
+| Version | `pyproject.toml` | Bumped to `0.6.1` |
+
+---
+
+## What is NOT changed
+
+- External API contract — all `/api/v1/` endpoints are backward-compatible.
+- MCP tool contracts — no MCP tool signatures changed.
+- Lakebase schema — no new tables or migrations.
+- v0.6.0 features — collaboration, graph analytics, edit-lock, audit trail, and all other
+  v0.6.0 capabilities remain intact.

--- a/releases/Roadmap_2026-07.md
+++ b/releases/Roadmap_2026-07.md
@@ -1,7 +1,7 @@
 # OntoBricks — Product Roadmap
 
 > **Version:** 0.6.x → beyond  
-> **Last updated:** 2026-07-01  
+> **Last updated:** 2026-07-06  
 > **Status:** Living document — updated after each release
 
 > **Disclaimer:** This roadmap represents the current product direction and planned investments as of the date above. It is provided for informational purposes only and is subject to change at any time without notice. The features, timelines, and priorities described here are aspirational and do not constitute a commitment, promise, or legal obligation to deliver any specific functionality by any specific date. Actual releases may differ materially from what is described here.
@@ -10,11 +10,11 @@
 
 ## Executive Summary
 
-OntoBricks is the only Databricks-native knowledge graph builder that combines ontology design, LLM-powered automation, formal reasoning, and interactive graph exploration in a single deployable App. Versions 0.4.0 (Lakebase as primary triple store), 0.5.0 (UX, workflow & governance), and 0.6.0 (collaborative comments & AI agents, graph analytics, mapping depth) have shipped; **v0.6.0 is the current stable line**.
+OntoBricks is the only Databricks-native knowledge graph builder that combines ontology design, LLM-powered automation, formal reasoning, and interactive graph exploration in a single deployable App. Versions 0.4.0 (Lakebase as primary triple store), 0.5.0 (UX, workflow & governance), 0.6.0 (collaborative comments & AI agents, graph analytics, mapping depth), and 0.6.1 (deploy hardening + read-only Switch fix) have shipped; **v0.6.1 is the current stable line**.
 
 The next phases of the roadmap focus on four strategic axes:
 
-1. **Graph engine expansion** — add Neo4j (Community, Enterprise, AuraDB) as a graph engine alongside Delta Lake and Lakebase, opening OntoBricks to hybrid Lakehouse + graph deployments (**v0.7.0**).
+1. **Graph engine expansion** — add **Delta Lake** as a first-class Graph DB engine (Spark SQL traversal directly on UC Delta tables, no Lakebase mirror required) and **Neo4j** (Community, Enterprise, AuraDB) as a property-graph engine, opening OntoBricks to pure-Lakehouse and hybrid Lakehouse + graph deployments (**v0.7.0**).
 2. **Unstructured data ingestion** — turn raw documents, PDFs, emails, and transcripts into trustworthy, ontology-governed graph entities through a native extraction and mapping pipeline built on Databricks AI Functions, Vector Search, and Unity Catalog (**v0.8.0**).
 3. **Workflow completeness** — close the remaining v0.6.0-deferred UX and automation items (ontology version diff, mapping multi-select & orphan validation, scheduled reasoning, temporal & recursive Datalog) folded into the **v0.8.0** release alongside unstructured ingestion.
 4. **Enterprise hardening** — fine-grained RBAC, multi-workspace federation, audit log, large-graph pagination, and one-command deployment (**v0.9.0**).
@@ -52,13 +52,15 @@ OntoBricks can be positioned as the **semantic layer for the Databricks Lakehous
 
 ## Current State — v0.6.x (July 2026)
 
-### Triple-store backends
+### Storage layers
 
 
-| Backend                        | Status | Use case                                          |
-| ------------------------------ | ------ | ------------------------------------------------- |
-| **Delta Lake (SQL Warehouse)** | GA     | Default; governed, UC-lineage, liquid clustering  |
-| **Lakebase (Postgres)**        | GA     | Databricks-native, app-managed or Lakeflow-synced |
+| Layer | Backend | Status | Use case |
+| ----- | ------- | ------ | -------- |
+| **Triple store** (governance) | **Delta Lake** (SQL Warehouse) | GA | Default; governed, UC-lineage, liquid clustering |
+| **Graph DB engine** (queries) | **Lakebase (Postgres)** | GA | Databricks-native, app-managed or Lakeflow-synced |
+| **Graph DB engine** (queries) | **Delta Lake** | Planned v0.7.0 | Spark SQL traversal directly on the UC Delta triple table — no Lakebase mirror |
+| **Graph DB engine** (queries) | **Neo4j** | Planned v0.7.0 | Property-graph export for existing Neo4j estates |
 
 
 ### Core capabilities
@@ -79,7 +81,7 @@ OntoBricks can be positioned as the **semantic layer for the Databricks Lakehous
 ### Known limitations (targeted in next releases)
 
 - A few v0.6.0 workflow items not yet delivered (ontology version diff/iteration, mapping multi-select & orphan validation, scheduled reasoning, temporal & recursive Datalog) — **targeted for v0.8.0**
-- Single graph-DB family (Delta Lake / Lakebase Postgres) — no Neo4j / property-graph export yet — **targeted for v0.7.0**
+- Graph DB engine is Lakebase-only today — Delta is the governance triple store but not yet selectable as the runtime Graph DB engine; no Neo4j / property-graph export yet — **targeted for v0.7.0**
 - No native unstructured data ingestion pipeline (document → entity extraction → knowledge graph) — **targeted for v0.8.0**
 - No SPARQL federation across multiple domain graphs
 - No cross-workspace domain federation
@@ -151,20 +153,58 @@ Also delivered (beyond the original plan):
 
 ---
 
-### v0.7.0 — Neo4j Connector (August 2026)
+### v0.6.1 — Patch Release (July 2026) — ✅ Delivered
 
-**Theme:** add Neo4j (Community, Enterprise, AuraDB) as a graph engine alongside Delta Lake and Lakebase, enabling customers with existing Neo4j infrastructure to use OntoBricks as their semantic design and mapping front-end.
+**Theme:** deploy hardening and read-only workflow fixes on top of v0.6.0.
 
-#### Why this matters
+
+| Capability | Status | Notes |
+| ---------- | ------ | ----- |
+| **Switch modal on published domains** | ✅ Delivered | Version picker enabled on IN-REVIEW/PUBLISHED; save-before-switch disabled ([#97](https://github.com/databrickslabs/ontobricks/issues/97)) |
+| **Auto-Map SQL deduplication** | ✅ Delivered | Prevents `AMBIGUOUS_REFERENCE` when `id`/`label` columns collide (PR #98 backport) |
+| **Databricks CLI profile in deploy** | ✅ Delivered | `DEFAULT_DATABRICKS_PROFILE` in `deploy.config.sh` |
+| **Lakebase deploy diagnostics** | ✅ Delivered | `_lakebase-diag.sh` with actionable CLI hints |
+| **Lakebase underscore/hyphen resolver** | ✅ Delivered | `_lakebase-resolve-db.py` tolerates `datname` vs resource-path slug mismatch |
+
+---
+
+### v0.7.0 — Graph Engine Expansion: Delta & Neo4j (August 2026)
+
+**Theme:** expand the pluggable `GraphDBFactory` with two new engines — **Delta Lake** as a native Graph DB backend (Spark SQL on UC triple tables, zero Lakebase dependency) and **Neo4j** (Community, Enterprise, AuraDB) for customers with existing property-graph infrastructure.
+
+#### Pillar 1 — Delta Lake Graph DB engine
+
+Today, every domain materializes a Delta view (governance) **and** mirrors triples into Lakebase Postgres (runtime Graph DB). Many deployments only need the Lakehouse layer. A first-class Delta Graph DB engine removes the Lakebase mirror requirement and lets the Knowledge Graph, reasoning, BFS, and analytics run directly against the UC Delta triple table via the SQL Warehouse.
+
+##### Why this matters
+
+- **Pure Lakehouse deployments** — Volume + SQL Warehouse only; no Postgres / Lakebase Autoscaling instance required for graph queries
+- **Single source of truth** — triples live in one governed Delta table; no sync drift between governance and query layers
+- **Full UC lineage** — every graph read and write stays inside Unity Catalog permissions and lineage
+- **Liquid clustering** — large graphs benefit from Delta's native clustering on `(subject, predicate, object)`
+- **Lower operational cost** — one fewer managed database for greenfield installs
+
+##### Key capabilities
+
+- Register `delta` in `GraphDBFactory` and `ALLOWED_GRAPH_ENGINES`; Settings → Graph DB card for catalog / schema / table selection
+- `DeltaGraphStore` implementing `GraphDBBackend` — delegates to `DeltaTripleStore` for `bulk_insert_iter`, BFS, transitive closure, and symmetric expansion via Spark SQL recursive CTEs
+- SPARQL → Spark SQL translation reused from the existing `SparqlTranslator` path (`query_dialect = "spark"`)
+- SWRL / OWL 2 RL reasoning compiled to Spark SQL on the Delta view (same path as today's triple-store layer)
+- Knowledge Graph Explorer, Graph Analytics, and Graph Chat query the Warehouse directly when Delta is selected
+- Build pipeline skips Lakebase `COPY FROM STDIN` / Lakeflow sync when Delta is the active engine
+- Health-check and connection status in Settings UI (warehouse reachability + table existence probe)
+- Optional — zero impact on Lakebase-first deployments (Lakebase remains the default)
+
+#### Pillar 2 — Neo4j connector
 
 Neo4j is the dominant graph database with 40%+ market share. Customers in finance, healthcare, and telco often have existing Neo4j deployments. A native connector means:
 
-- **No data duplication** — triples are materialized directly into Neo4j as nodes and relationships; no intermediate Delta table needed
+- **Property-graph export** — triples materialized directly into Neo4j as nodes and relationships
 - **Native graph queries** — Cypher traversal, shortest path, and graph algorithms run on Neo4j; OntoBricks handles ontology design and mapping
 - **Hybrid Lakehouse + graph** — raw data stays in Delta/UC; the knowledge graph lives in Neo4j; OntoBricks bridges both worlds
 - **Removes the last objection** for prospects evaluating OntoBricks against a pure graph-DB-plus-ETL approach
 
-#### OWL → Property Graph mapping
+##### OWL → Property Graph mapping
 
 
 | OWL concept                | Neo4j representation                                    |
@@ -177,7 +217,7 @@ Neo4j is the dominant graph database with 40%+ market share. Customers in financ
 | Named graph                | Neo4j database (Enterprise) or label prefix (Community) |
 
 
-#### Key capabilities
+##### Key capabilities
 
 - Batch node and relationship upsert from the OntoBricks build pipeline
 - Typed node label promotion from `rdf:type` triples
@@ -185,7 +225,7 @@ Neo4j is the dominant graph database with 40%+ market share. Customers in financ
 - Knowledge Graph visualization sourced from Neo4j via Bolt
 - Health-check and connection status in the Settings UI
 - AuraDB support with automatic connection string detection
-- Optional install — zero impact on Volume-only deployments
+- Optional install — zero impact on Volume-only / Delta-only deployments
 
 ---
 
@@ -261,8 +301,9 @@ The design leans on existing Databricks platform capabilities rather than reinve
 
 | Feature                                          | v0.4 | v0.5 | v0.6 | v0.7 | v0.8 | v0.9 | v1.0 |
 | ------------------------------------------------ | ---- | ---- | ---- | ---- | ---- | ---- | ---- |
-| Delta Lake triple store                          | ✅    | ✅    | ✅    | ✅    | ✅    | ✅    | ✅    |
-| **Lakebase named-graph triple store**            | ✅    | ✅    | ✅    | ✅    | ✅    | ✅    | ✅    |
+| Delta Lake triple store (governance)             | ✅    | ✅    | ✅    | ✅    | ✅    | ✅    | ✅    |
+| **Lakebase Graph DB engine**                     | ✅    | ✅    | ✅    | ✅    | ✅    | ✅    | ✅    |
+| **Delta Lake Graph DB engine**                   | —    | —    | —    | ✅    | ✅    | ✅    | ✅    |
 | **UX & workflow improvements**                   | —    | ✅    | ✅    | ✅    | ✅    | ✅    | ✅    |
 | **Version lifecycle & review**                   | —    | ✅    | ✅    | ✅    | ✅    | ✅    | ✅    |
 | **Auto quality rules**                           | —    | ✅    | ✅    | ✅    | ✅    | ✅    | ✅    |
@@ -289,17 +330,17 @@ The design leans on existing Databricks platform capabilities rather than reinve
 ## Graph Engine Comparison (v0.4+)
 
 
-| Capability                  | Delta Lake                | Lakebase (v0.4)                 | Neo4j (v0.7)                  |
+| Capability                  | Delta (Graph DB, v0.7)    | Lakebase (v0.4)                 | Neo4j (v0.7)                  |
 | --------------------------- | ------------------------- | ------------------------------- | ----------------------------- |
 | **Storage**                 | Delta table in UC         | Postgres (Lakebase Autoscaling) | Neo4j database or AuraDB      |
 | **Query language**          | Spark SQL                 | Postgres SQL + SPARQL subset    | Cypher                        |
 | **SPARQL support**          | Via Spark SQL translation | Native                          | Via OntoBricks adapter        |
 | **Named graphs**            | Per-domain Delta table    | ✅                               | ✅                             |
-| **Transactional reasoning** | Append only               | ✅                               | ✅                             |
+| **Transactional reasoning** | Append via Warehouse      | ✅                               | ✅                             |
 | **Multi-hop traversal**     | Recursive CTE (Spark)     | Optimized indexes + CTE         | Native Cypher (best-in-class) |
 | **Governance / lineage**    | Full UC lineage           | UC synced table                 | External                      |
-| **Deployment**              | Built-in                  | Optional extra                  | Optional extra                |
-| **Best for**                | Production, governed data | Databricks-native + SPARQL      | Customers with existing Neo4j |
+| **Deployment**              | SQL Warehouse only        | Optional extra                  | Optional extra                |
+| **Best for**                | Pure Lakehouse, governed  | Databricks-native + SPARQL      | Customers with existing Neo4j |
 
 
 ---
@@ -310,7 +351,8 @@ The design leans on existing Databricks platform capabilities rather than reinve
 2. **Entity resolution strategy** — semantic Vector Search matching is fast but approximate; exact string deduplication is cheaper. The right mix is use-case dependent. We plan to ship both and make the strategy configurable per domain.
 3. **Lakebase SPARQL subset scope** — BGP + FILTER covers 80% of use cases; OPTIONAL and UNION add another 15%. Aggregates and property paths are deferred to a later patch.
 4. **Neo4j Community vs Enterprise** — named graphs as separate databases require Neo4j Enterprise. Community edition support will use label prefixing as a documented workaround.
-5. **Auto quality rules confidence** — the v0.5.0 business-rules generator is advisory (suggest + review/accept). How aggressively should auto-suggested rules be applied? Auto-apply with confidence thresholds is deferred pending feedback.
+5. **Delta Graph DB vs dual-layer** — when Delta is the active Graph DB engine, the build pipeline can skip the Lakebase mirror entirely. Domains that need both UC lineage *and* low-latency Postgres reads can keep Lakebase as the engine. Migration UX is deferred to v0.9.0.
+6. **Auto quality rules confidence** — the v0.5.0 business-rules generator is advisory (suggest + review/accept). How aggressively should auto-suggested rules be applied? Auto-apply with confidence thresholds is deferred pending feedback.
 
 ---
 

--- a/scripts/_lakebase-diag.sh
+++ b/scripts/_lakebase-diag.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Shared Lakebase connection troubleshooting hints (stderr).
+# Source from deploy/bootstrap scripts after Lakebase vars are known.
+#
+# Usage:
+#   _lakebase_print_diag_hints "<reason>" <project> <branch> [datname] [db_segment] [config_file]
+
+_lakebase_print_diag_hints() {
+    local reason="$1"
+    local project="$2"
+    local branch="$3"
+    local database="${4:-}"
+    local db_segment="${5:-}"
+    local config_file="${6:-scripts/deploy.config.sh}"
+
+    local branch_path="projects/${project}/branches/${branch}"
+    local profile_prefix=""
+    [[ -n "${DATABRICKS_CONFIG_PROFILE:-}" ]] && profile_prefix=" --profile ${DATABRICKS_CONFIG_PROFILE}"
+
+    echo "" >&2
+    echo "  Lakebase diagnostics (${reason}):" >&2
+    echo "    project  : ${project}" >&2
+    echo "    branch   : ${branch}" >&2
+    [[ -n "$database" ]] && echo "    datname  : ${database} (DEFAULT_LAKEBASE_DATABASE — use status.postgres_database)" >&2
+    [[ -n "$db_segment" ]] && echo "    db id    : ${db_segment} (resource path segment / database_id, often db-… or hyphenated)" >&2
+    echo "" >&2
+    echo "  Two names per database (easy to confuse):" >&2
+    echo "    • status.postgres_database → PGDATABASE / DEFAULT_LAKEBASE_DATABASE (underscores OK)" >&2
+    echo "    • name trailing segment    → Apps postgres binding / db-… id (hyphens only, RFC-1123)" >&2
+    echo "    If your datname is ontobricks_demo, the resource id may show ontobricks-demo." >&2
+    echo "" >&2
+    echo "  Common causes:" >&2
+    echo "    • Wrong LAKEBASE_PROJECT or LAKEBASE_BRANCH in ${config_file}" >&2
+    echo "    • Postgres database not created yet — run: scripts/setup-lakebase.sh" >&2
+    echo "    • DEFAULT_LAKEBASE_DATABASE set to the hyphenated resource id instead of postgres_database" >&2
+    echo "    • LAKEBASE_DATABASE datname ≠ status.postgres_database from the API" >&2
+    echo "    • LAKEBASE_DATABASE_RESOURCE_SEGMENT unset or stale (must be the db-… id, not the datname)" >&2
+    echo "    • Project created via the Databricks UI (use setup-lakebase.sh for Synced Tables compatibility)" >&2
+    echo "    • CLI profile/workspace mismatch (check DEFAULT_DATABRICKS_PROFILE in ${config_file})" >&2
+    echo "" >&2
+    echo "  Inspect the live project:" >&2
+    echo "    databricks${profile_prefix} postgres list-databases \"${branch_path}\" -o json" >&2
+    echo "    databricks${profile_prefix} api get /api/2.0/postgres/${branch_path}/endpoints" >&2
+    echo "" >&2
+    echo "  In list-databases JSON, set DEFAULT_LAKEBASE_DATABASE from status.postgres_database;" >&2
+    echo "  set LAKEBASE_DATABASE_RESOURCE_SEGMENT from the trailing name segment (db-… or slug)." >&2
+}

--- a/scripts/_lakebase-resolve-db.py
+++ b/scripts/_lakebase-resolve-db.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Resolve Lakebase db segment + Postgres datname from list-databases JSON.
+
+Lakebase exposes two different names per database:
+  - ``name`` trailing segment (``database_id``, RFC-1123 — hyphens only)
+  - ``status.postgres_database`` (actual ``PGDATABASE`` / datname — underscores)
+
+Callers may pass either form in *requested*; we match exact first, then
+underscore/hyphen slug variants on both fields.
+
+Prints ``<segment>\\t<postgres_database>`` on stdout, or nothing if no match.
+"""
+from __future__ import annotations
+
+import json
+import sys
+
+
+def _slug_variants(value: str) -> set[str]:
+    if not value:
+        return set()
+    return {value, value.replace("_", "-"), value.replace("-", "_")}
+
+
+def resolve(requested: str, raw: str) -> tuple[str, str] | None:
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    dbs = data if isinstance(data, list) else data.get("databases", [])
+    wanted = _slug_variants(requested)
+    if not wanted:
+        return None
+
+    for db in dbs:
+        status = db.get("status") or {}
+        pg_name = (status.get("postgres_database") or "").strip()
+        segment = (db.get("name") or "").rsplit("/", 1)[-1]
+        if pg_name in wanted or segment in wanted:
+            return segment, pg_name
+    return None
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print("usage: list-databases.json | _lakebase-resolve-db.py <requested>", file=sys.stderr)
+        sys.exit(2)
+    hit = resolve(sys.argv[1], sys.stdin.read())
+    if hit:
+        segment, pg_name = hit
+        print(f"{segment}\t{pg_name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bootstrap-lakebase-perms.sh
+++ b/scripts/bootstrap-lakebase-perms.sh
@@ -65,6 +65,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR/.."
 
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/_lakebase-diag.sh"
+
 INSTANCE="${INSTANCE:-ontobricks-app}"
 BRANCH="${BRANCH:-${LAKEBASE_BRANCH:-production}}"
 DATABASE="${DATABASE:-ontobricks_registry}"
@@ -112,7 +115,7 @@ done
 
 if ! databricks current-user me >/dev/null 2>&1; then
     echo "ERROR: Databricks CLI not authenticated." >&2
-    echo "       Run: databricks auth login --host https://<workspace>" >&2
+    echo "       Run: databricks auth login --host https://<workspace>${DATABRICKS_CONFIG_PROFILE:+ --profile $DATABRICKS_CONFIG_PROFILE}" >&2
     exit 1
 fi
 
@@ -168,8 +171,9 @@ PY
 )"
 if [[ -z "$ENDPOINT_INFO" ]]; then
     echo "ERROR: Could not resolve a primary endpoint for Lakebase Autoscaling project '${INSTANCE}' on branch '${BRANCH}'." >&2
-    echo "       Check 'databricks api get /api/2.0/postgres/projects/${INSTANCE}/branches/${BRANCH}/endpoints'" >&2
-    echo "       and confirm project/branch values match the app postgres resource binding." >&2
+    _lakebase_print_diag_hints \
+        "no postgres endpoint for project/branch" \
+        "${INSTANCE}" "${BRANCH}" "${DATABASE}"
     exit 1
 fi
 PGHOST="$(printf '%s\n' "$ENDPOINT_INFO" | sed -n 1p)"
@@ -192,7 +196,10 @@ PGPASSWORD="$(databricks api post /api/2.0/postgres/credentials \
     --json "{\"endpoint\":\"${ENDPOINT_PATH}\"}" \
     | python3 -c 'import sys,json; print(json.load(sys.stdin).get("token",""))')"
 if [[ -z "$PGPASSWORD" ]]; then
-    echo "ERROR: Failed to mint a Lakebase JWT for instance '${INSTANCE}'." >&2
+    echo "ERROR: Failed to mint a Lakebase JWT for project '${INSTANCE}' on branch '${BRANCH}'." >&2
+    _lakebase_print_diag_hints \
+        "postgres credentials API failed (endpoint: ${ENDPOINT_PATH})" \
+        "${INSTANCE}" "${BRANCH}" "${DATABASE}"
     exit 1
 fi
 export PGPASSWORD
@@ -244,7 +251,14 @@ done
 # Ensure the target schema actually exists. If not, the operator
 # probably ran the script before initialising the registry.
 if ! psql "$PGCONN" -tAc "SELECT 1 FROM information_schema.schemata WHERE schema_name='${SCHEMA}'" \
-        | grep -q 1; then
+        2>/dev/null | grep -q 1; then
+    if ! psql "$PGCONN" -tAc "SELECT 1" >/dev/null 2>&1; then
+        echo "ERROR: Cannot connect to Lakebase Postgres (host=${PGHOST}, dbname=${DATABASE})." >&2
+        _lakebase_print_diag_hints \
+            "psql connection failed — wrong datname or endpoint" \
+            "${INSTANCE}" "${BRANCH}" "${DATABASE}"
+        exit 1
+    fi
     echo "ERROR: Schema '${SCHEMA}' does not exist in database '${DATABASE}'." >&2
     echo "       Initialise the registry from the OntoBricks Settings UI first." >&2
     echo "       CAN_USE grants above were applied — re-run after initialisation" >&2

--- a/scripts/deploy.config.sh
+++ b/scripts/deploy.config.sh
@@ -10,9 +10,11 @@
 # │  TO DEPLOY A NEW INSTANCE:                                      │
 # │    1. Set DEFAULT_APP_NAME.                                     │
 # │    2. Set DEFAULT_LAKEBASE_DATABASE (existing Postgres datname).│
-# │    3. Optionally set DEFAULT_LAKEBASE_SCHEMA if you want a      │
+# │    3. Optionally set DEFAULT_DATABRICKS_PROFILE if you use a    │
+# │       non-default Databricks CLI profile.                       │
+# │    4. Optionally set DEFAULT_LAKEBASE_SCHEMA if you want a      │
 # │       specific schema name (defaults to app-name slug).         │
-# │    4. Optionally set DEFAULT_REGISTRY_SCHEMA if the UC schema   │
+# │    5. Optionally set DEFAULT_REGISTRY_SCHEMA if the UC schema   │
 # │       differs from the app-name slug.                           │
 # │                                                                  │
 # │  The Lakebase db-… resource segment is resolved automatically   │
@@ -35,6 +37,11 @@ DEFAULT_APP_NAME="ontobricks-060"
 # ── 0b. Workspace constants ──────────────────────────────────────────
 # Set once for your workspace. Shared across all instances deployed here.
 
+# Databricks CLI profile (`databricks auth profiles`). Leave empty to use
+# the CLI default profile. Exported as DATABRICKS_CONFIG_PROFILE for all
+# `databricks` invocations when this file is sourced (make deploy, bootstrap, …).
+DEFAULT_DATABRICKS_PROFILE="fe-vm-bcayla-demos"
+
 # SQL Warehouse
 DEFAULT_WAREHOUSE_ID="d2096aa075ad44a3"
 
@@ -47,7 +54,10 @@ DEFAULT_REGISTRY_VOLUME="registry"
 # Lakebase Autoscaling project + branch
 DEFAULT_LAKEBASE_PROJECT="ontobricks-demo2"
 DEFAULT_LAKEBASE_BRANCH="production"
-# Postgres database (datname) on the shared Lakebase instance.
+# Postgres database (datname) on the shared Lakebase instance — the value of
+# status.postgres_database from list-databases (underscores OK). Do NOT copy the
+# hyphenated database_id from the resource path name; those differ when the
+# datname contains underscores (API uses hyphens only in database_id / RFC-1123).
 # Each app gets its own SCHEMA inside this database.
 DEFAULT_LAKEBASE_DATABASE="ontobricks_demo"
 # Postgres schema inside the Lakebase database, Each instance should have its own schema for isolation.
@@ -67,6 +77,12 @@ DEFAULT_APP_MLFLOW_TRACKING_URI="databricks"
 
 # ── DAB target ───────────────────────────────────────────────────────
 DEFAULT_DAB_TARGET="dev-lakebase"
+
+# ── 0e. Databricks CLI profile ───────────────────────────────────────
+# Override for one-off runs: DATABRICKS_CONFIG_PROFILE=my-profile make deploy
+if [[ -n "${DATABRICKS_CONFIG_PROFILE:-$DEFAULT_DATABRICKS_PROFILE}" ]]; then
+    export DATABRICKS_CONFIG_PROFILE="${DATABRICKS_CONFIG_PROFILE:-$DEFAULT_DATABRICKS_PROFILE}"
+fi
 
 # ── 1. Apps ─────────────────────────────────────────────────────────
 export APP_NAME="${APP_NAME:-$DEFAULT_APP_NAME}"

--- a/scripts/deploy.config.sh
+++ b/scripts/deploy.config.sh
@@ -40,7 +40,7 @@ DEFAULT_APP_NAME="ontobricks-060"
 # Databricks CLI profile (`databricks auth profiles`). Leave empty to use
 # the CLI default profile. Exported as DATABRICKS_CONFIG_PROFILE for all
 # `databricks` invocations when this file is sourced (make deploy, bootstrap, …).
-DEFAULT_DATABRICKS_PROFILE="fe-vm-bcayla-demos"
+DEFAULT_DATABRICKS_PROFILE="${DEFAULT_DATABRICKS_PROFILE:-DEFAULT}"
 
 # SQL Warehouse
 DEFAULT_WAREHOUSE_ID="d2096aa075ad44a3"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -74,6 +74,9 @@ ok()   { echo "  ${_C_GRN}✓${_C_RST} $*"; }
 warn() { echo "  ${_C_YEL}⚠${_C_RST}  $*" >&2; }
 die()  { echo "" >&2; echo "${_C_RED}✗ ERROR:${_C_RST} $*" >&2; exit 1; }
 
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/_lakebase-diag.sh"
+
 # Fired by the ERR trap on any uncaught failure (set -e). Reports which
 # step failed, the exact command + line, and a targeted hint.
 _on_error() {
@@ -88,9 +91,16 @@ _on_error() {
             echo "  hint    : inspect the error above; re-run \`databricks bundle validate -t ${TARGET:-?}\`" >&2
             echo "            and double-check the --var values in ${CONFIG_FILE:-scripts/deploy.config.sh}." >&2 ;;
         *auth*|*Authentication*)
-            echo "  hint    : run \`databricks auth login --host https://<workspace>\` then retry." >&2 ;;
+            echo "  hint    : run \`databricks auth login --host https://<workspace>${DATABRICKS_CONFIG_PROFILE:+ --profile $DATABRICKS_CONFIG_PROFILE}\` then retry." >&2 ;;
         *Render*)
             echo "  hint    : check scripts/_render-app-yaml.py and the APP_* values in ${CONFIG_FILE:-scripts/deploy.config.sh}." >&2 ;;
+        *Lakebase*)
+            if $IS_LAKEBASE; then
+                _lakebase_print_diag_hints "step failed: ${CURRENT_STEP}" \
+                    "${LAKEBASE_PROJECT}" "${LAKEBASE_BRANCH}" \
+                    "${LAKEBASE_DATABASE}" "${LAKEBASE_DATABASE_RESOURCE_SEGMENT:-}" \
+                    "${CONFIG_FILE:-scripts/deploy.config.sh}"
+            fi ;;
     esac
     exit "$rc"
 }
@@ -157,6 +167,7 @@ EXPECTED_PG_DATABASE_PATH="${EXPECTED_PG_BRANCH_PATH}/databases/${LAKEBASE_DATAB
 
 echo "${_C_BLU}=== OntoBricks Deployment (DAB) ===${_C_RST}"
 echo "Config  : $CONFIG_FILE"
+[[ -n "${DATABRICKS_CONFIG_PROFILE:-}" ]] && echo "Profile : $DATABRICKS_CONFIG_PROFILE"
 echo "Target  : $TARGET"
 echo "App     : $APP_NAME ($APP_RESOURCE_KEY)"
 echo "MCP app : $MCP_APP_NAME ($MCP_APP_RESOURCE_KEY)"
@@ -237,23 +248,26 @@ if $IS_LAKEBASE; then
         _branch_path="projects/${LAKEBASE_PROJECT}/branches/${LAKEBASE_BRANCH}"
         _resolve_out="$(databricks postgres list-databases "$_branch_path" -o json 2>/dev/null || true)"
         if [[ -n "$_resolve_out" ]]; then
-            LAKEBASE_DATABASE_RESOURCE_SEGMENT="$(printf '%s' "$_resolve_out" \
-                | python3 -c "
-import sys, json
-raw = sys.stdin.read()
-try:
-    data = json.loads(raw)
-    dbs = data if isinstance(data, list) else data.get('databases', [])
-    for db in dbs:
-        if db.get('status', {}).get('postgres_database') == '${LAKEBASE_DATABASE}':
-            print(db.get('name','').split('/')[-1])
-            break
-except Exception:
-    pass
-" 2>/dev/null || true)"
+            _resolve_hit="$(printf '%s' "$_resolve_out" \
+                | python3 scripts/_lakebase-resolve-db.py "${LAKEBASE_DATABASE}" 2>/dev/null || true)"
+            if [[ -n "$_resolve_hit" ]]; then
+                LAKEBASE_DATABASE_RESOURCE_SEGMENT="${_resolve_hit%%$'\t'*}"
+                _resolved_datname="${_resolve_hit#*$'\t'}"
+                if [[ -n "$_resolved_datname" && "$_resolved_datname" != "$LAKEBASE_DATABASE" ]]; then
+                    warn "LAKEBASE_DATABASE='${LAKEBASE_DATABASE}' matched a database whose Postgres datname is '${_resolved_datname}'."
+                    warn "Underscores in datnames often appear as hyphens in the resource id — update DEFAULT_LAKEBASE_DATABASE in ${CONFIG_FILE} to '${_resolved_datname}'."
+                    LAKEBASE_DATABASE="$_resolved_datname"
+                    export APP_LAKEBASE_DATABASE="$_resolved_datname"
+                    info "Auto-corrected LAKEBASE_DATABASE → '${_resolved_datname}' for this deploy."
+                fi
+            fi
         fi
         if [[ -z "${LAKEBASE_DATABASE_RESOURCE_SEGMENT:-}" ]]; then
-            die "Could not resolve db-… resource segment for database '${LAKEBASE_DATABASE}'. Set LAKEBASE_DATABASE_RESOURCE_SEGMENT explicitly or check LAKEBASE_PROJECT/LAKEBASE_BRANCH."
+            _lakebase_print_diag_hints \
+                "no db-… segment matches datname '${LAKEBASE_DATABASE}'" \
+                "${LAKEBASE_PROJECT}" "${LAKEBASE_BRANCH}" \
+                "${LAKEBASE_DATABASE}" "" "${CONFIG_FILE}"
+            die "Could not resolve db-… resource segment for database '${LAKEBASE_DATABASE}'. Set LAKEBASE_DATABASE_RESOURCE_SEGMENT explicitly or fix LAKEBASE_PROJECT/LAKEBASE_BRANCH/DATABASE in ${CONFIG_FILE}."
         fi
         export LAKEBASE_DATABASE_RESOURCE_SEGMENT
         info "Resolved db-… segment: ${LAKEBASE_DATABASE_RESOURCE_SEGMENT} (from database '${LAKEBASE_DATABASE}')"
@@ -272,6 +286,7 @@ except Exception:
             break
         fi
     done
+    EXPECTED_PG_DATABASE_PATH="${EXPECTED_PG_BRANCH_PATH}/databases/${LAKEBASE_DATABASE_RESOURCE_SEGMENT}"
 fi
 ok "deploy.config values present"
 
@@ -284,7 +299,7 @@ esac
 # ── 2. Verify Databricks authentication ─────────────────────────────
 begin_step "Verify Databricks authentication"
 if ! databricks current-user me &>/dev/null; then
-    die "Not authenticated to Databricks. Run: databricks auth login --host https://<workspace> (or export DATABRICKS_HOST/DATABRICKS_TOKEN)."
+    die "Not authenticated to Databricks. Run: databricks auth login --host https://<workspace>${DATABRICKS_CONFIG_PROFILE:+ --profile $DATABRICKS_CONFIG_PROFILE} (or export DATABRICKS_HOST/DATABRICKS_TOKEN)."
 fi
 DATABRICKS_USERNAME="$(databricks current-user me -o json \
     | python3 -c 'import sys,json; print(json.load(sys.stdin).get("userName","<unknown>"))' 2>/dev/null || echo "<unknown>")"
@@ -395,11 +410,19 @@ except Exception:
             fi
         else
             CHECK_FAILED=$((CHECK_FAILED + 1))
-            warn "Lakebase database '${LAKEBASE_DATABASE_RESOURCE_SEGMENT}' not found under ${EXPECTED_PG_BRANCH_PATH}. List ids with: databricks postgres list-databases \"${EXPECTED_PG_BRANCH_PATH}\" -o json"
+            warn "Lakebase database '${LAKEBASE_DATABASE_RESOURCE_SEGMENT}' not found under ${EXPECTED_PG_BRANCH_PATH}."
+            _lakebase_print_diag_hints \
+                "db-… segment not listed under project/branch" \
+                "${LAKEBASE_PROJECT}" "${LAKEBASE_BRANCH}" \
+                "${LAKEBASE_DATABASE}" "${LAKEBASE_DATABASE_RESOURCE_SEGMENT}" "${CONFIG_FILE}"
         fi
     else
         CHECK_FAILED=$((CHECK_FAILED + 1))
-        warn "could not list Lakebase databases for ${EXPECTED_PG_BRANCH_PATH} — verify LAKEBASE_PROJECT/LAKEBASE_BRANCH and that the project was created via scripts/setup-lakebase.sh."
+        warn "could not list Lakebase databases for ${EXPECTED_PG_BRANCH_PATH} (API error or project/branch not found)."
+        _lakebase_print_diag_hints \
+            "postgres list-databases call failed" \
+            "${LAKEBASE_PROJECT}" "${LAKEBASE_BRANCH}" \
+            "${LAKEBASE_DATABASE}" "${LAKEBASE_DATABASE_RESOURCE_SEGMENT:-}" "${CONFIG_FILE}"
     fi
 fi
 
@@ -411,6 +434,12 @@ fi
 if $DRY_RUN; then
     echo ""
     if [[ $CHECK_FAILED -gt 0 ]]; then
+        if $IS_LAKEBASE; then
+            _lakebase_print_diag_hints \
+                "dry-run resource check failed" \
+                "${LAKEBASE_PROJECT}" "${LAKEBASE_BRANCH}" \
+                "${LAKEBASE_DATABASE}" "${LAKEBASE_DATABASE_RESOURCE_SEGMENT:-}" "${CONFIG_FILE}"
+        fi
         die "DRY RUN found ${CHECK_FAILED} resource problem(s) above. Fix them in ${CONFIG_FILE} before deploying."
     fi
     echo "${_C_GRN}=== Dry run OK ===${_C_RST}  preflight + auth + render + validate + resource checks all passed."
@@ -664,6 +693,10 @@ if $IS_LAKEBASE; then
             -a "$MCP_APP_NAME"; then
         echo ""
         echo "  ⚠ Lakebase permission bootstrap did not complete cleanly."
+        _lakebase_print_diag_hints \
+            "bootstrap-lakebase-perms.sh failed (connection, endpoint, or schema grants)" \
+            "${LAKEBASE_PROJECT}" "${LAKEBASE_BRANCH}" \
+            "${LAKEBASE_DATABASE}" "${LAKEBASE_DATABASE_RESOURCE_SEGMENT:-}" "${CONFIG_FILE}"
         echo "    If the registry schema does not exist yet, initialise it"
         echo "    from Settings > Registry > Initialize and re-run:"
         echo "      scripts/bootstrap-lakebase-perms.sh \\"

--- a/src/agents/tools/mapping.py
+++ b/src/agents/tools/mapping.py
@@ -9,6 +9,7 @@ import re
 from typing import Callable, Dict, List, Optional
 
 from back.core.logging import get_logger
+from back.core.sqlwizard.SQLWizardService import SQLWizardService
 from agents.tools.context import ToolContext
 
 logger = get_logger(__name__)
@@ -53,6 +54,9 @@ def tool_submit_entity_mapping(
         re.sub(r"\s+LIMIT\s+\d+\s*$", "", sql_query, flags=re.IGNORECASE)
         .strip()
         .rstrip(";")
+    )
+    clean_sql = SQLWizardService._deduplicate_select_columns(
+        clean_sql, mapping_type="entity"
     )
 
     # Restrict attribute_mappings to attributes declared in the ontology for this entity.
@@ -180,6 +184,9 @@ def tool_submit_relationship_mapping(
         re.sub(r"\s+LIMIT\s+\d+\s*$", "", sql_query, flags=re.IGNORECASE)
         .strip()
         .rstrip(";")
+    )
+    clean_sql = SQLWizardService._deduplicate_select_columns(
+        clean_sql, mapping_type="relationship"
     )
 
     def _extract_label(value: str) -> str:

--- a/src/back/core/sqlwizard/SQLWizardService.py
+++ b/src/back/core/sqlwizard/SQLWizardService.py
@@ -615,7 +615,8 @@ class SQLWizardService:
         token = col_expr.strip().split(".")[-1].strip('`"')
         return token
 
-    def _deduplicate_select_columns(self, sql: str, mapping_type: str = None) -> str:
+    @staticmethod
+    def _deduplicate_select_columns(sql: str, mapping_type: str = None) -> str:
         """Ensure every column in the SELECT list has a unique output name.
 
         - For *entity* queries: guarantees the first column is aliased AS ID
@@ -624,13 +625,16 @@ class SQLWizardService:
           AS source_id and the second AS target_id.
         - For any query: if two columns share the same effective output name,
           the later occurrence(s) get a numeric suffix (e.g. col_2).
+
+        Made static so it can be reused from agents/tools/mapping.py's Auto-Map
+        submission tools without constructing a full SQLWizardService.
         """
-        parsed = self._parse_select_columns(sql)
+        parsed = SQLWizardService._parse_select_columns(sql)
         if parsed is None or len(parsed) != 3:
             return sql
 
         prefix, select_part, rest = parsed
-        columns = self._split_columns(select_part)
+        columns = SQLWizardService._split_columns(select_part)
 
         if not columns:
             return sql
@@ -646,7 +650,7 @@ class SQLWizardService:
         for idx, alias in required.items():
             if idx < len(columns):
                 col = columns[idx]
-                eff = self._effective_name(col)
+                eff = SQLWizardService._effective_name(col)
                 if eff.upper() != alias.upper():
                     # Strip any existing alias first
                     col_stripped = re.sub(
@@ -658,10 +662,10 @@ class SQLWizardService:
         seen = {}  # lowercase name -> count
         deduped = []
         for col in columns:
-            eff = self._effective_name(col).lower()
+            eff = SQLWizardService._effective_name(col).lower()
             if eff in seen:
                 seen[eff] += 1
-                new_alias = f"{self._effective_name(col)}_{seen[eff]}"
+                new_alias = f"{SQLWizardService._effective_name(col)}_{seen[eff]}"
                 col_stripped = re.sub(
                     r"\s+AS\s+\S+\s*$", "", col, flags=re.IGNORECASE
                 ).strip()

--- a/tests/units/agents/test_mapping_tools.py
+++ b/tests/units/agents/test_mapping_tools.py
@@ -1,0 +1,95 @@
+"""Regression tests for agents/tools/mapping.py's SQL deduplication guard.
+
+Real-world bug: the auto-mapping agent's own prompt instructs it to alias
+the id/label source column (e.g. "AS Label") *and* repeat it under its
+original name for attribute mapping. When that original name is itself
+"id"/"label" (case-insensitive) — e.g. a `gold_segment` table with an
+actual column named `label` — this produces two columns Databricks
+resolves as the same one, and the digital-twin build fails with
+`AMBIGUOUS_REFERENCE` at Sync time. `tool_submit_entity_mapping` /
+`tool_submit_relationship_mapping` must deduplicate before persisting the
+mapping, regardless of what the LLM actually generated.
+"""
+
+import pytest
+
+from agents.tools.context import ToolContext
+from agents.tools.mapping import (
+    tool_submit_entity_mapping,
+    tool_submit_relationship_mapping,
+)
+
+
+@pytest.fixture
+def ctx():
+    return ToolContext(host="https://test.databricks.com", token="fake-token")
+
+
+@pytest.mark.unit
+class TestEntityMappingLabelCollision:
+    def test_label_column_named_label_is_deduplicated(self, ctx):
+        """The exact production shape: label_column="Label" sourced from a
+        physical column literally named "label", also listed as a
+        standalone attribute — the classic self-collision."""
+        sql = (
+            "SELECT segment_id AS ID, label AS Label, segment_id, label, description "
+            "FROM catalog.schema.gold_segment WHERE segment_id IS NOT NULL"
+        )
+        tool_submit_entity_mapping(
+            ctx,
+            class_uri="http://test.org/ontology#Segment",
+            class_name="Segment",
+            sql_query=sql,
+            id_column="ID",
+            label_column="Label",
+            attribute_mappings={"hasLabel": "label", "hasDescription": "description"},
+        )
+        assert len(ctx.entity_mappings) == 1
+        stored_sql = ctx.entity_mappings[0]["sql_query"]
+
+        # The duplicate "label" column must be renamed, not left colliding
+        # with "Label" under case-insensitive resolution.
+        assert "label AS Label" in stored_sql
+        assert ", label," not in stored_sql, f"unresolved duplicate in: {stored_sql}"
+
+    def test_no_collision_when_columns_are_distinct(self, ctx):
+        """Sanity check: distinct column names pass through unchanged."""
+        sql = (
+            "SELECT viewer_id AS ID, display_name AS Label, viewer_id, display_name, region "
+            "FROM catalog.schema.gold_viewer WHERE viewer_id IS NOT NULL"
+        )
+        tool_submit_entity_mapping(
+            ctx,
+            class_uri="http://test.org/ontology#Viewer",
+            class_name="Viewer",
+            sql_query=sql,
+            id_column="ID",
+            label_column="Label",
+            attribute_mappings={"hasRegion": "region"},
+        )
+        stored_sql = ctx.entity_mappings[0]["sql_query"]
+        assert "viewer_id AS ID" in stored_sql
+        assert "display_name AS Label" in stored_sql
+
+
+@pytest.mark.unit
+class TestRelationshipMappingDedup:
+    def test_relationship_columns_are_deduplicated_too(self, ctx):
+        sql = (
+            "SELECT viewer_id AS source_id, segment_id AS target_id "
+            "FROM catalog.schema.gold_viewer WHERE viewer_id IS NOT NULL AND segment_id IS NOT NULL"
+        )
+        tool_submit_relationship_mapping(
+            ctx,
+            property_uri="http://test.org/ontology#belongsTo",
+            property_name="belongsTo",
+            sql_query=sql,
+            source_id_column="source_id",
+            target_id_column="target_id",
+            domain="http://test.org/ontology#Viewer",
+            range_class="http://test.org/ontology#Segment",
+        )
+        assert len(ctx.relationships) == 1
+        stored_sql = ctx.relationships[0]["sql_query"]
+        assert "AS source_id" in stored_sql
+        assert "AS target_id" in stored_sql

--- a/tests/units/scripts/test_lakebase_resolve_db.py
+++ b/tests/units/scripts/test_lakebase_resolve_db.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/_lakebase-resolve-db.py (no pytest import of bash)."""
+import importlib.util
+import pathlib
+import unittest
+
+_ROOT = pathlib.Path(__file__).resolve().parents[3]
+_SPEC = importlib.util.spec_from_file_location(
+    "_lakebase_resolve_db",
+    _ROOT / "scripts" / "_lakebase-resolve-db.py",
+)
+_mod = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(_mod)
+resolve = _mod.resolve
+
+_LIST_JSON = """{
+  "databases": [
+    {
+      "name": "projects/demo/branches/production/databases/ontobricks-demo",
+      "status": {"postgres_database": "ontobricks_demo"}
+    },
+    {
+      "name": "projects/demo/branches/production/databases/db-abc123",
+      "status": {"postgres_database": "other_db"}
+    }
+  ]
+}"""
+
+
+class TestLakebaseResolveDb(unittest.TestCase):
+    def test_match_by_postgres_datname(self):
+        hit = resolve("ontobricks_demo", _LIST_JSON)
+        self.assertEqual(hit, ("ontobricks-demo", "ontobricks_demo"))
+
+    def test_match_by_hyphenated_resource_id(self):
+        hit = resolve("ontobricks-demo", _LIST_JSON)
+        self.assertEqual(hit, ("ontobricks-demo", "ontobricks_demo"))
+
+    def test_no_match(self):
+        self.assertIsNone(resolve("missing", _LIST_JSON))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- **Deploy hardening** — Lakebase `db-…` resolver with underscore/hyphen slug tolerance, shared diagnostics helper (`_lakebase-diag.sh`), and env-overridable Databricks CLI profile in `deploy.config.sh`
- **Auto-Map SQL fix** (PR #98 backport) — deduplicate `id`/`label` column collisions that caused `AMBIGUOUS_REFERENCE` during digital-twin builds
- **Release documentation** — `ReleaseNotes_V0.6.1.md`, roadmap update (v0.6.1 delivered, Delta Graph DB planned for v0.7.0), changelog entries

## Commits

1. `c472c90` — fix(deploy): Lakebase resolver, diagnostics, and CLI profile config
2. `2ff29b8` — fix(mapping): deduplicate Auto-Map SQL columns colliding with ID/Label alias
3. `dc278d4` — chore: add changelog and Eric Poilvet to contributors (PR #98 backport)
4. `b2fa7c7` — docs(release): add v0.6.1 release notes and roadmap update

## Test plan

- [x] `uv run pytest -q -m "not scenario"` — 2993 passed
- [x] `make deploy` to `ontobricks-060` / `mcp-ontobricks-060` — both apps RUNNING, `/healthz` → 200
- [x] Lakebase bootstrap + schema migrations applied cleanly
- [ ] Verify Switch modal on IN-REVIEW/PUBLISHED domain (version picker enabled, save-before-switch disabled)
- [ ] Verify Auto-Map with a table whose column is literally named `label` — build completes without `AMBIGUOUS_REFERENCE`