### PR TITLE
fix(agents): handle list-style message content from Claude endpoints

### DIFF
--- a/src/agents/engine_base.py
+++ b/src/agents/engine_base.py
@@ -184,7 +184,13 @@ def extract_message_content(llm_response: dict) -> str:
     """Extract text content from an OpenAI-style or predictions-style LLM response."""
     choices = llm_response.get("choices", [])
     if choices:
-        return choices[0].get("message", {}).get("content", "") or ""
+        content = choices[0].get("message", {}).get("content") or ""
+        # Claude endpoints return content as a list of blocks, not a string
+        if isinstance(content, list):
+            content = "".join(
+                b if isinstance(b, str) else b.get("text", "") for b in content
+            )
+        return content
     preds = llm_response.get("predictions", [])
     if preds:
         return preds[0] if isinstance(preds[0], str) else str(preds[0])


### PR DESCRIPTION
## What

`extract_message_content` (`src/agents/engine_base.py`) assumed `choices[0].message.content` is always a string. Databricks **Claude** serving endpoints (`databricks-claude-*`) return it as a list of content blocks (`[{"type": "text", "text": "…"}]`), so the function returned a list and downstream callers — e.g. `agent_owl_generator/engine.py` doing `content.strip().startswith("@prefix")` — crashed with `'list' object has no attribute 'strip'`. This broke **Ontology Wizard → Generate** and **Mapping → Auto-Map** for any domain using a Claude endpoint (which the app offers in its own endpoint picker).

Fixes #107.

## Fix

Flatten list content to text at the single extraction choke point. Plain-string content (OpenAI-format / Gemini endpoints) is not a list and is returned unchanged, so other endpoint types are unaffected; list elements that are plain strings are also handled.

```python
content = choices[0].get("message", {}).get("content") or ""
# Claude endpoints return content as a list of blocks, not a string
if isinstance(content, list):
    content = "".join(
        b if isinstance(b, str) else b.get("text", "") for b in content
    )
return content
```

## Testing

Verified across endpoint shapes: OpenAI string (passthrough), Claude list-of-blocks (flattened), list-of-strings (joined), `None`/empty (→ `""`), predictions-style (passthrough). All agents that call `extract_message_content` (owl generator, auto-assignment, business-rules, auto-icon) benefit.

This pull request and its description were written by Isaac.
