### PR TITLE
test(dtwin): add regression test for KG /sync/filter on non-DRAFT versions

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,6 +10,7 @@ Thank you to everyone who has contributed to OntoBricks!
 | Dermot Smyth | [@dermotsmyth-db](https://github.com/dermotsmyth-db) | Contributor |
 | Hugues Journeau | [@hourdays](https://github.com/hourdays) | Contributor |
 | Eric Poilvet | [@epoilvet](https://github.com/epoilvet) | Contributor |
+| Brian Castelino | [@bcastelino](https://github.com/bcastelino) | Contributor |
 
 ## How to Contribute
 

--- a/changelogs/v0.6.1/briancastelino_2026-07-08.log
+++ b/changelogs/v0.6.1/briancastelino_2026-07-08.log
@@ -1,0 +1,13 @@
+## Add regression test for KG filtering on non-DRAFT versions
+
+### Context
+While using the Knowledge Graph explorer, I ran into a `403` ("This version is PUBLISHED; set it back to DRAFT to edit") when filtering the graph on a locked version. On investigation, that bug was already fixed upstream in commit 9d9c120, which replaced the broad `/dtwin/sync/` entry in `_STATUS_GATE_EDIT_PATHS` with the explicit write paths `/dtwin/sync/start` and `/dtwin/sync/load`, so the read-only `POST /dtwin/sync/filter` is no longer status-gated. To guard against a future regression, I am adding an end-to-end middleware dispatch test that locks in the correct behaviour.
+
+### Changes
+1. `tests/units/auth/test_permission_middleware.py`: I added `test_kg_filter_allowed_on_non_draft`, an end-to-end middleware dispatch test verifying `POST /dtwin/sync/filter` is allowed on `PUBLISHED` and `IN-REVIEW` versions. This complements the existing function-level test `test_dtwin_non_gated_paths_remain_open` by exercising the full dispatch path.
+
+### Modified files
+- `tests/units/auth/test_permission_middleware.py`
+
+### Test results
+I ran `tests/units/auth/test_permission_middleware.py` and got 255 passed, including the new regression test.

--- a/tests/units/auth/test_permission_middleware.py
+++ b/tests/units/auth/test_permission_middleware.py
@@ -1308,3 +1308,15 @@ class TestLifecycleGateInDispatch:
             path="/ontology/entities",
         )
         assert result.get("passed")
+
+    @pytest.mark.parametrize("status", ["PUBLISHED", "IN-REVIEW"])
+    def test_kg_filter_allowed_on_non_draft(self, status):
+        """KG filtering is read-only; it must stay available on locked versions."""
+        _, _, result = _dispatch_with_status(
+            ROLE_APP_USER, ROLE_BUILDER,
+            version_status=status,
+            path="/dtwin/sync/filter",
+        )
+        assert result.get("passed"), (
+            f"KG filter should be allowed on {status} version"
+        )


### PR DESCRIPTION
## Summary

While using the Knowledge Graph explorer I hit a 403 ("This version is
PUBLISHED; set it back to DRAFT to edit") when filtering a locked version. I
tracked the cause to the broad `/dtwin/sync/` entry in
`_STATUS_GATE_EDIT_PATHS`, which matched `/dtwin/sync/filter` via `startswith`.
That was already fixed upstream in 9d9c120 (the prefix was narrowed to
`/dtwin/sync/start` and `/dtwin/sync/load`), so no source change is needed.

This PR adds an end-to-end middleware dispatch test that locks in the correct
behaviour, so a future edit to the gate lists cannot silently reintroduce the
regression. It complements the existing function-level test
[test_dtwin_non_gated_paths_remain_open](cci:1://file:///c:/Users/BrianCastelino/Projects/personal/ontobricks/tests/units/auth/test_permission_middleware.py:1250:4-1256:41) by exercising the full dispatch path.

## Type of change

- [ ] feat, new feature
- [ ] fix, bug fix
- [ ] docs, documentation only
- [ ] refactor, no behaviour change
- [x] test, tests only
- [ ] perf, perf improvement
- [ ] ci / build / chore, tooling