### PR TITLE
fix(dtwin): sync large literal objects via object_hash primary key (#108)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,6 +10,7 @@ Thank you to everyone who has contributed to OntoBricks!
 | Dermot Smyth | [@dermotsmyth-db](https://github.com/dermotsmyth-db) | Contributor |
 | Hugues Journeau | [@hourdays](https://github.com/hourdays) | Contributor |
 | Eric Poilvet | [@epoilvet](https://github.com/epoilvet) | Contributor |
+| Brian Castelino | [@bcastelino](https://github.com/bcastelino) | Contributor |
 
 ## How to Contribute
 

--- a/changelogs/v0.6.1/briancastelino_2026-07-08.log
+++ b/changelogs/v0.6.1/briancastelino_2026-07-08.log
@@ -1,0 +1,51 @@
+## Fix triple store sync failure on large literal objects (issue #108)
+
+### Context
+Building or synchronizing the Knowledge Graph aborted whenever a mapped
+literal `object` exceeded the Postgres B-tree limit of 2704 bytes, surfacing
+as an opaque "Triple store sync failed" with an underlying
+`psycopg.errors.ProgramLimitExceeded: index row size ... exceeds btree ...`.
+This is realistic data, not an edge case: long text columns (descriptions,
+notes, log messages) are common and Auto-Map maps every column by default, so
+the literal becomes part of an index tuple. The root cause is that every index
+containing the raw `object` column is subject to the limit: the
+`(subject, predicate, object)` primary key on the `_sync` and `__app` tables,
+the `(predicate, object)` and `(object, predicate)` secondary indexes, and,
+in `managed_synced` mode, the Lakeflow-created synced table keyed on the same
+columns.
+
+### Changes
+1. `src/back/core/graphdb/lakebase/_companion_ddl.py`: I key the primary key of
+   the `_sync` and `__app` tables on a generated `object_hash bytea GENERATED
+   ALWAYS AS (sha256(convert_to(object, 'UTF8'))) STORED` column instead of the
+   raw `object`, so arbitrarily long literals load while triple uniqueness is
+   preserved. `sha256` / `convert_to` are Postgres built-ins, so no `pgcrypto`
+   extension is required. The object-bearing secondary indexes are made
+   size-guarded partial indexes (`WHERE octet_length(object) <= 2000`) so normal
+   data keeps identical query plans and oversized literals are simply not
+   indexed by value. I added `ensure_object_hash_pk`, an idempotent, best-effort
+   migration that upgrades pre-existing tables (adds the column, swaps a legacy
+   `(subject, predicate, object)` primary key, drops the legacy full-object
+   indexes) without ever aborting a build.
+2. `src/back/core/helpers/SQLHelpers.py` (+ `__init__.py`): I added
+   `add_object_hash_column`, which wraps the triple-producing Spark SELECT so
+   the Delta view also emits `sha2(object, 256) AS object_hash` for
+   `managed_synced` synced tables.
+3. `src/back/objects/digitaltwin/_build_pipeline.py` and
+   `src/back/objects/registry/scheduler.py`: in `managed_synced` mode the Delta
+   view now emits `object_hash` and the Lakebase synced table is keyed on
+   `["subject", "predicate", "object_hash"]` instead of the raw `object`.
+
+### Modified files
+- `src/back/core/graphdb/lakebase/_companion_ddl.py`
+- `src/back/core/helpers/SQLHelpers.py`
+- `src/back/core/helpers/__init__.py`
+- `src/back/objects/digitaltwin/_build_pipeline.py`
+- `src/back/objects/registry/scheduler.py`
+- `tests/units/core/test_companion_ddl_object_hash.py`
+- `tests/units/dtwin/test_build_pipeline_streaming.py`
+
+### Test results
+I ran `tests/units/core` and `tests/units/dtwin` and got 654 passed, 1 skipped
+(the psycopg-gated `test_lakebase_flat_store` module, which requires psycopg in
+CI), including the new `test_companion_ddl_object_hash` suite.

--- a/src/back/core/graphdb/lakebase/_companion_ddl.py
+++ b/src/back/core/graphdb/lakebase/_companion_ddl.py
@@ -19,9 +19,30 @@ side so SPARQL / KG-search readers see a uniform schema.
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from back.core.helpers import safe_identifier
+
+logger = logging.getLogger(__name__)
+
+# Generated column carrying a fixed-width SHA-256 digest of ``object``.
+# Postgres B-tree index entries cannot exceed ~2704 bytes, so a triple whose
+# literal ``object`` is larger than that aborts any index that includes the raw
+# column (the primary key and the object-bearing secondary indexes).  Keying the
+# primary key on this 32-byte digest instead of the unbounded ``object`` lets
+# arbitrarily long literals load while preserving triple uniqueness.  ``sha256``
+# / ``convert_to`` are Postgres built-ins (no ``pgcrypto`` extension needed).
+_OBJECT_HASH_COL = (
+    "object_hash bytea GENERATED ALWAYS AS "
+    "(sha256(convert_to(object, 'UTF8'))) STORED"
+)
+
+# Secondary indexes that include the raw ``object`` are made partial so they
+# still serve normal-sized data (identical query plans) but simply skip the rare
+# oversized literal rather than failing the insert.  2000 bytes leaves head-room
+# under the 2704 limit for the accompanying ``predicate`` / ``subject`` columns.
+_LONG_OBJECT_PARTIAL = " WHERE octet_length(object) <= 2000"
 
 
 def _safe(name: str) -> str:
@@ -68,18 +89,84 @@ def ensure_synced(cur: Any, schema: str, synced: str) -> None:
             object TEXT NOT NULL,
             datatype TEXT,
             lang TEXT,
-            PRIMARY KEY (subject, predicate, object)
+            {_OBJECT_HASH_COL},
+            PRIMARY KEY (subject, predicate, object_hash)
         )
         """
     )
-    for sfx, cols in (
-        ("sp", "subject, predicate"),
-        ("po", "predicate, object"),
-        ("ops", "object, predicate"),
+    ensure_object_hash_pk(cur, synced)
+    _ensure_triple_indexes(cur, synced)
+
+
+def _ensure_triple_indexes(cur: Any, table: str) -> None:
+    """Create the standard triple-lookup indexes.
+
+    ``sp`` covers subject/predicate access; ``po`` / ``ops`` cover object-bearing
+    access but are made partial (:data:`_LONG_OBJECT_PARTIAL`) so an oversized
+    literal never trips the B-tree row-size limit at insert time.
+    """
+    for sfx, cols, partial in (
+        ("sp", "subject, predicate", ""),
+        ("po", "predicate, object", _LONG_OBJECT_PARTIAL),
+        ("ops", "object, predicate", _LONG_OBJECT_PARTIAL),
     ):
         cur.execute(
-            f"CREATE INDEX IF NOT EXISTS {_idx_name(synced, sfx)} "
-            f"ON {synced} ({cols})"
+            f"CREATE INDEX IF NOT EXISTS {_idx_name(table, sfx)} "
+            f"ON {table} ({cols}){partial}"
+        )
+
+
+def ensure_object_hash_pk(cur: Any, table: str) -> None:
+    """Idempotently migrate an existing triples table to the hashed-object PK.
+
+    Adds the generated ``object_hash`` column, swaps a legacy
+    ``(subject, predicate, object)`` primary key for
+    ``(subject, predicate, object_hash)``, and drops the legacy full-object
+    B-tree indexes so the size-guarded partial ones created by
+    :func:`_ensure_triple_indexes` take over.  A brand-new table created with the
+    current DDL is already in the target shape, so every step is a no-op.
+
+    Best-effort: a table owned by a different role (e.g. a Lakeflow-created
+    ``_sync`` left behind by a previous ``managed_synced`` build) cannot be
+    altered by the app service principal; the failure is logged and swallowed so
+    a build is never aborted by the migration itself.
+    """
+    bare = table.split(".")[-1].strip("\"")
+    try:
+        cur.execute(
+            f"ALTER TABLE {table} ADD COLUMN IF NOT EXISTS {_OBJECT_HASH_COL}"
+        )
+        cur.execute(
+            "DO $$ "
+            "DECLARE pk_name text; pk_cols text; "
+            "BEGIN "
+            "  SELECT c.conname, "
+            "         string_agg(a.attname, ',' ORDER BY k.ord) "
+            "    INTO pk_name, pk_cols "
+            "  FROM pg_constraint c "
+            "  JOIN pg_class t ON t.oid = c.conrelid "
+            "  JOIN pg_namespace n ON n.oid = t.relnamespace "
+            "  JOIN unnest(c.conkey) WITH ORDINALITY AS k(attnum, ord) ON true "
+            "  JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = k.attnum "
+            f"  WHERE t.relname = {bare!r} "
+            "    AND n.nspname = ANY(current_schemas(false)) "
+            "    AND c.contype = 'p' "
+            "  GROUP BY c.conname; "
+            "  IF pk_cols = 'subject,predicate,object' THEN "
+            f"    EXECUTE format('ALTER TABLE %I DROP CONSTRAINT %I', {bare!r}, pk_name); "
+            f"    EXECUTE format('ALTER TABLE %I ADD PRIMARY KEY "
+            f"(subject, predicate, object_hash)', {bare!r}); "
+            "  END IF; "
+            "END $$"
+        )
+        cur.execute(f"DROP INDEX IF EXISTS {_idx_name(bare, 'po')}")
+        cur.execute(f"DROP INDEX IF EXISTS {_idx_name(bare, 'ops')}")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "object_hash migration skipped for %s (non-fatal; new tables already "
+            "use the hashed PK): %s",
+            table,
+            exc,
         )
 
 
@@ -121,19 +208,13 @@ def ensure_companion(cur: Any, schema: str, companion: str) -> None:
             object TEXT NOT NULL,
             datatype TEXT,
             lang TEXT,
-            PRIMARY KEY (subject, predicate, object)
+            {_OBJECT_HASH_COL},
+            PRIMARY KEY (subject, predicate, object_hash)
         )
         """
     )
-    for sfx, cols in (
-        ("sp", "subject, predicate"),
-        ("po", "predicate, object"),
-        ("ops", "object, predicate"),
-    ):
-        cur.execute(
-            f"CREATE INDEX IF NOT EXISTS {_idx_name(companion, sfx)} "
-            f"ON {companion} ({cols})"
-        )
+    ensure_object_hash_pk(cur, companion)
+    _ensure_triple_indexes(cur, companion)
 
 
 def ensure_union_view(

--- a/src/back/core/graphdb/lakebase/_companion_ddl.py
+++ b/src/back/core/graphdb/lakebase/_companion_ddl.py
@@ -19,12 +19,19 @@ side so SPARQL / KG-search readers see a uniform schema.
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from back.core.helpers import safe_identifier
+from back.core.logging import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
+
+# SQLSTATE 42501 (insufficient_privilege) is what Postgres raises for
+# ``must be owner of table`` / ``permission denied``.  These are the only
+# migration failures we treat as non-fatal: a triples table owned by a
+# different role (e.g. a Lakeflow-created ``_sync`` from a previous
+# ``managed_synced`` build) simply cannot be altered by the app principal.
+_OWNERSHIP_SQLSTATES = frozenset({"42501"})
 
 # Generated column carrying a fixed-width SHA-256 digest of ``object``.
 # Postgres B-tree index entries cannot exceed ~2704 bytes, so a triple whose
@@ -116,6 +123,22 @@ def _ensure_triple_indexes(cur: Any, table: str) -> None:
         )
 
 
+def _is_ownership_error(exc: Exception) -> bool:
+    """Return ``True`` only for the expected ownership/permission failure.
+
+    Prefers the psycopg ``sqlstate`` (42501) and falls back to a message probe
+    so the check still works if the driver wraps or re-raises the error without
+    preserving the SQLSTATE.
+    """
+    sqlstate = getattr(exc, "sqlstate", None) or getattr(
+        getattr(exc, "diag", None), "sqlstate", None
+    )
+    if sqlstate in _OWNERSHIP_SQLSTATES:
+        return True
+    msg = str(exc).lower()
+    return "must be owner" in msg or "permission denied" in msg
+
+
 def ensure_object_hash_pk(cur: Any, table: str) -> None:
     """Idempotently migrate an existing triples table to the hashed-object PK.
 
@@ -162,9 +185,15 @@ def ensure_object_hash_pk(cur: Any, table: str) -> None:
         cur.execute(f"DROP INDEX IF EXISTS {_idx_name(bare, 'po')}")
         cur.execute(f"DROP INDEX IF EXISTS {_idx_name(bare, 'ops')}")
     except Exception as exc:  # noqa: BLE001
+        # Only ownership/permission failures are expected and non-fatal; any
+        # other error (undefined function, syntax error, ...) is a real defect
+        # that must surface rather than silently leave the legacy PK/index shape
+        # in place and re-trigger the original ProgramLimitExceeded later.
+        if not _is_ownership_error(exc):
+            raise
         logger.warning(
-            "object_hash migration skipped for %s (non-fatal; new tables already "
-            "use the hashed PK): %s",
+            "object_hash migration skipped for %s (non-fatal; table is owned by "
+            "another role and new tables already use the hashed PK): %s",
             table,
             exc,
         )

--- a/src/back/core/helpers/SQLHelpers.py
+++ b/src/back/core/helpers/SQLHelpers.py
@@ -24,6 +24,30 @@ class SQLHelpers:
         return str(value).replace("\\", "\\\\").replace("'", "''")
 
     @staticmethod
+    def add_object_hash_column(select_sql: str) -> str:
+        """Wrap a triple-producing SELECT so it also emits an ``object_hash`` column.
+
+        ``managed_synced`` Lakebase tables key their primary key on
+        ``object_hash`` (a SHA-256 of the literal ``object``) instead of the raw
+        ``object`` column, so literals larger than the Postgres B-tree limit
+        (2704 bytes) can be synced without aborting the pipeline.  ``sha2`` is a
+        Spark SQL built-in; the extra column is ignored by the ``app_managed``
+        read paths, which select ``subject`` / ``predicate`` / ``object``
+        explicitly.
+
+        The wrap uses a derived table so it composes with the CTE-based SQL the
+        SPARQL→Spark translator emits.
+        """
+        inner = (select_sql or "").strip().rstrip(";")
+        if not inner:
+            return select_sql
+        return (
+            "SELECT _obh.*, "
+            "sha2(CAST(_obh.object AS STRING), 256) AS object_hash\n"
+            f"FROM (\n{inner}\n) _obh"
+        )
+
+    @staticmethod
     def validate_table_name(table_name: str) -> None:
         """Raise :class:`~back.core.errors.ValidationError` if *table_name* is empty.
 

--- a/src/back/core/helpers/__init__.py
+++ b/src/back/core/helpers/__init__.py
@@ -12,6 +12,7 @@ from back.core.helpers.URIHelpers import URIHelpers  # noqa: F401
 # imports can pull ``back.core.helpers`` again while this module is still
 # initializing (e.g. triplestore → helpers for ``sql_escape``).
 sql_escape = SQLHelpers.sql_escape
+add_object_hash_column = SQLHelpers.add_object_hash_column
 validate_table_name = SQLHelpers.validate_table_name
 effective_view_table = SQLHelpers.effective_view_table
 effective_graph_name = SQLHelpers.effective_graph_name

--- a/src/back/objects/digitaltwin/_build_pipeline.py
+++ b/src/back/objects/digitaltwin/_build_pipeline.py
@@ -508,8 +508,17 @@ class _BuildPipeline:
         )
         try:
             catalog, schema, vname = self.parts
+            view_sql = self.spark_sql
+            if self._is_lakebase_synced:
+                # managed_synced: Lakeflow keys the synced PK on ``object_hash``
+                # so literals larger than the Postgres B-tree limit (2704 bytes)
+                # can sync. app_managed skips this — its Postgres DDL generates
+                # the hash column locally, so the extra Spark compute is avoided.
+                from back.core.helpers import add_object_hash_column
+
+                view_sql = add_object_hash_column(view_sql)
             view_ok, view_msg = self.source_client.create_or_replace_view(
-                catalog, schema, vname, self.spark_sql
+                catalog, schema, vname, view_sql
             )
             if not view_ok:
                 if self.is_api:
@@ -891,7 +900,10 @@ class _BuildPipeline:
             _synced_obj = mgr.ensure(
                 synced_uc,
                 source_table_full_name=self.view_table,
-                primary_key_columns=["subject", "predicate", "object"],
+                # PK on the SHA-256 ``object_hash`` (emitted by the VIEW) rather
+                # than the raw ``object`` so literals over the Postgres B-tree
+                # limit (2704 bytes) can sync. See add_object_hash_column.
+                primary_key_columns=["subject", "predicate", "object_hash"],
                 sync_mode=self.store.sync_table_mode,
             )
             # ensure() may have used a fallback name (ghost control-plane state);

--- a/src/back/objects/registry/scheduler.py
+++ b/src/back/objects/registry/scheduler.py
@@ -1011,7 +1011,15 @@ def _generate_sql_from_r2rml(domain, domain_name: str):
     )
     res = sparql.translate_sparql_to_spark(sparql_q, ent, None, rels, dialect="spark")
 
-    return res["sql"], view_table, graph_name, base_uri, ent, rels
+    # Emit an ``object_hash`` column so a managed_synced Lakebase table can key
+    # its PK on the hash instead of the raw ``object`` (literals over the
+    # Postgres B-tree limit of 2704 bytes would otherwise abort the sync). The
+    # column is ignored by the app_managed streaming reader, which selects
+    # subject/predicate/object explicitly.
+    from back.core.helpers import add_object_hash_column
+
+    view_sql = add_object_hash_column(res["sql"])
+    return view_sql, view_table, graph_name, base_uri, ent, rels
 
 
 def _stream_into_store(store, src, graph_name: str, select_sql: str, batch: int = 5000) -> int:
@@ -1076,7 +1084,9 @@ def _apply_synced_pipeline(
     mgr.ensure(
         synced_uc,
         source_table_full_name=view_table,
-        primary_key_columns=["subject", "predicate", "object"],
+        # PK on the SHA-256 ``object_hash`` emitted by the VIEW (see
+        # _generate_sql_from_r2rml) so oversized literals can sync.
+        primary_key_columns=["subject", "predicate", "object_hash"],
         sync_mode=store.sync_table_mode,
     )
     store.ensure_synced_companion(graph_name)

--- a/tests/units/core/test_companion_ddl_object_hash.py
+++ b/tests/units/core/test_companion_ddl_object_hash.py
@@ -1,0 +1,91 @@
+"""Unit tests for the object_hash primary-key fix (issue #108).
+
+Postgres B-tree index tuples cannot exceed ~2704 bytes, so keying the triple
+tables on the raw ``object`` column aborts the sync whenever a mapped literal is
+larger than that.  These tests pin the DDL that keys the primary key on a
+fixed-width ``object_hash`` digest and makes the object-bearing secondary
+indexes size-guarded, plus the migration helper for pre-existing tables and the
+Spark-side ``object_hash`` column used by ``managed_synced``.
+"""
+
+from unittest.mock import MagicMock
+
+from back.core.graphdb.lakebase import _companion_ddl
+from back.core.helpers import add_object_hash_column
+
+
+def _executed(cur: MagicMock) -> str:
+    """Concatenate every SQL string passed to ``cur.execute`` for substring checks."""
+    return "\n".join(str(c[0][0]) for c in cur.execute.call_args_list)
+
+
+class TestEnsureSyncedDDL:
+    def test_synced_table_keys_pk_on_object_hash(self):
+        cur = MagicMock()
+        _companion_ddl.ensure_synced(cur, "ontobricks_graph", "g_v1_sync")
+        sql = _executed(cur)
+        assert "object_hash bytea GENERATED ALWAYS AS" in sql
+        assert "sha256(convert_to(object, 'UTF8'))" in sql
+        assert "PRIMARY KEY (subject, predicate, object_hash)" in sql
+        # The raw object must NOT be part of the primary key any more.
+        assert "PRIMARY KEY (subject, predicate, object)" not in sql
+
+    def test_companion_table_keys_pk_on_object_hash(self):
+        cur = MagicMock()
+        _companion_ddl.ensure_companion(cur, "ontobricks_graph", "g_v1__app")
+        sql = _executed(cur)
+        assert "PRIMARY KEY (subject, predicate, object_hash)" in sql
+        assert "PRIMARY KEY (subject, predicate, object)" not in sql
+
+    def test_object_bearing_indexes_are_size_guarded(self):
+        cur = MagicMock()
+        _companion_ddl.ensure_synced(cur, "ontobricks_graph", "g_v1_sync")
+        idx_stmts = [
+            str(c[0][0])
+            for c in cur.execute.call_args_list
+            if "CREATE INDEX" in str(c[0][0])
+        ]
+        po = next(s for s in idx_stmts if "(predicate, object)" in s)
+        ops = next(s for s in idx_stmts if "(object, predicate)" in s)
+        assert "WHERE octet_length(object) <= 2000" in po
+        assert "WHERE octet_length(object) <= 2000" in ops
+        # The subject/predicate index carries no object column, so it stays full.
+        sp = next(s for s in idx_stmts if "(subject, predicate)" in s)
+        assert "octet_length" not in sp
+
+
+class TestObjectHashMigration:
+    def test_migration_adds_column_swaps_pk_and_drops_legacy_indexes(self):
+        cur = MagicMock()
+        _companion_ddl.ensure_object_hash_pk(cur, "g_v1_sync")
+        sql = _executed(cur)
+        assert "ADD COLUMN IF NOT EXISTS object_hash bytea" in sql
+        # PK swap only fires for the legacy (subject,predicate,object) shape.
+        assert "IF pk_cols = 'subject,predicate,object' THEN" in sql
+        assert "ADD PRIMARY KEY (subject, predicate, object_hash)" in sql
+        # Legacy full-object secondary indexes are dropped so the partial ones win.
+        assert "DROP INDEX IF EXISTS g_g_v1_sync_po" in sql
+        assert "DROP INDEX IF EXISTS g_g_v1_sync_ops" in sql
+
+    def test_migration_is_best_effort_on_owner_error(self):
+        cur = MagicMock()
+        cur.execute.side_effect = RuntimeError("must be owner of table g_v1_sync")
+        # Must not raise: a table owned by another role should never abort a build.
+        _companion_ddl.ensure_object_hash_pk(cur, "g_v1_sync")
+
+
+class TestAddObjectHashColumn:
+    def test_wraps_select_with_sha2_object_hash(self):
+        wrapped = add_object_hash_column(
+            "SELECT subject, predicate, object FROM t"
+        )
+        assert "sha2(CAST(_obh.object AS STRING), 256) AS object_hash" in wrapped
+        assert "SELECT subject, predicate, object FROM t" in wrapped
+
+    def test_strips_trailing_semicolon_before_wrapping(self):
+        wrapped = add_object_hash_column("SELECT 1 AS object;")
+        assert wrapped.count(";") == 0
+        assert "object_hash" in wrapped
+
+    def test_empty_input_returns_input_unchanged(self):
+        assert add_object_hash_column("") == ""

--- a/tests/units/core/test_companion_ddl_object_hash.py
+++ b/tests/units/core/test_companion_ddl_object_hash.py
@@ -10,6 +10,8 @@ Spark-side ``object_hash`` column used by ``managed_synced``.
 
 from unittest.mock import MagicMock
 
+import pytest
+
 from back.core.graphdb.lakebase import _companion_ddl
 from back.core.helpers import add_object_hash_column
 
@@ -72,6 +74,21 @@ class TestObjectHashMigration:
         cur.execute.side_effect = RuntimeError("must be owner of table g_v1_sync")
         # Must not raise: a table owned by another role should never abort a build.
         _companion_ddl.ensure_object_hash_pk(cur, "g_v1_sync")
+
+    def test_migration_is_best_effort_on_insufficient_privilege_sqlstate(self):
+        cur = MagicMock()
+        exc = RuntimeError("permission problem")
+        exc.sqlstate = "42501"  # insufficient_privilege
+        cur.execute.side_effect = exc
+        _companion_ddl.ensure_object_hash_pk(cur, "g_v1_sync")
+
+    def test_migration_reraises_unexpected_error(self):
+        cur = MagicMock()
+        # A real DDL defect (e.g. undefined function) must surface, not be
+        # swallowed, so it cannot silently leave the legacy PK/index shape.
+        cur.execute.side_effect = RuntimeError("function sha256(bytea) does not exist")
+        with pytest.raises(RuntimeError, match="does not exist"):
+            _companion_ddl.ensure_object_hash_pk(cur, "g_v1_sync")
 
 
 class TestAddObjectHashColumn:

--- a/tests/units/dtwin/test_build_pipeline_streaming.py
+++ b/tests/units/dtwin/test_build_pipeline_streaming.py
@@ -183,7 +183,7 @@ class TestApplyViaSyncedPipeline:
         assert ensure_kwargs["primary_key_columns"] == [
             "subject",
             "predicate",
-            "object",
+            "object_hash",
         ]
         assert ensure_kwargs["sync_mode"] == "snapshot"
         pipe.store.ensure_synced_companion.assert_called_once_with(pipe.graph_name)


### PR DESCRIPTION
## Summary

Building/synchronizing the Knowledge Graph aborted whenever a mapped literal
`object` exceeded the Postgres B-tree limit of 2704 bytes
(`psycopg ProgramLimitExceeded` on the `_sync_pkey` index). The root cause is
that every index containing the raw `object` is subject to the limit: the
`(subject, predicate, object)` primary key on `_sync`/`__app`, the
`(predicate, object)` / `(object, predicate)` secondary indexes, and the
Lakeflow-created synced-table PK in managed_synced mode.

This keys the primary key on a generated `object_hash` (SHA-256) column,
makes the object-bearing secondary indexes size-guarded partial indexes,
migrates existing tables best-effort, and emits `object_hash` in the Delta
view for managed_synced. No `pgcrypto` extension required.

Fixes #108.

## Type of change
- [x] fix, bug fix

## What changed
- Re-keyed the `_sync` and `__app` companion tables on a generated `object_hash bytea GENERATED ALWAYS AS (sha256(convert_to(object, 'UTF8'))) STORED` column instead of the raw `object`.
- Made the object-bearing secondary indexes (`(predicate, object)` and `(object, predicate)`) partial indexes guarded by `WHERE octet_length(object) <= 2000`.
- Added an idempotent, best-effort migration helper [ensure_object_hash_pk](cci:1://file:///c:/Users/BrianCastelino/Projects/personal/ontobricks/src/back/core/graphdb/lakebase/_companion_ddl.py:118:0-169:9) that upgrades pre-existing tables without aborting a build.
- Added [add_object_hash_column](cci:1://file:///c:/Users/BrianCastelino/Projects/personal/ontobricks/src/back/core/helpers/SQLHelpers.py:25:4-47:9) in `back.core.helpers` so the `managed_synced` Delta view emits `sha2(object, 256) AS object_hash`.
- Updated `managed_synced` pipelines in [_build_pipeline.py](cci:7://file:///c:/Users/BrianCastelino/Projects/personal/ontobricks/src/back/objects/digitaltwin/_build_pipeline.py:0:0-0:0) and [scheduler.py](cci:7://file:///c:/Users/BrianCastelino/Projects/personal/ontobricks/src/back/objects/registry/scheduler.py:0:0-0:0) to key the Lakebase synced table on `["subject", "predicate", "object_hash"]`.
- Added unit tests in [tests/units/core/test_companion_ddl_object_hash.py](cci:7://file:///c:/Users/BrianCastelino/Projects/personal/ontobricks/tests/units/core/test_companion_ddl_object_hash.py:0:0-0:0) and updated [tests/units/dtwin/test_build_pipeline_streaming.py](cci:7://file:///c:/Users/BrianCastelino/Projects/personal/ontobricks/tests/units/dtwin/test_build_pipeline_streaming.py:0:0-0:0).

## Author checklist
- [x] PR title follows Conventional Commits
- [x] Changelog entry added ([changelogs/v0.6.1/briancastelino_2026-07-08.log](cci:7://file:///c:/Users/BrianCastelino/Projects/personal/ontobricks/changelogs/v0.6.1/briancastelino_2026-07-08.log:0:0-0:0))
- [x] Tests added/updated ([tests/units/core/test_companion_ddl_object_hash.py](cci:7://file:///c:/Users/BrianCastelino/Projects/personal/ontobricks/tests/units/core/test_companion_ddl_object_hash.py:0:0-0:0))
- [ ] pre-commit run locally

> pre-commit could not run locally (the `uv`-managed hook toolchain would not
> install in my environment). CI pre-commit / lint will run on this PR.

## MLflow eval
N/A, this change is infrastructure (Lakebase DDL / sync), not an LLM agent.