### PR TITLE
Perf(graphdb) Optimize finding subjects with local id's

### DIFF
--- a/changelogs/2026-07-08.log
+++ b/changelogs/2026-07-08.log
@@ -30,25 +30,24 @@ Tests: skipped — not run in this environment
 
 ---
 
-## Refine URI alias expansion with bucketed ANY probes
+## Refine URI alias expansion with OR-of-ANY probes
 
 Context: Follow-up benchmarking on production-like Lakebase data showed the
 VALUES-join alias expansion path was slower than OR-LIKE under high pattern
-counts. A bucketed fixed-length suffix probe strategy completed large sets
-reliably (including ~1300 IDs) with materially lower latency.
+counts. Further benchmarking showed the fastest stable strategy was a single
+SQL statement with one fixed-length ``RIGHT(subject, k) = ANY(ARRAY[...])``
+clause per distinct suffix length, avoiding both giant OR-LIKE chains and
+multi-round-trip bucket execution.
 
 Changes:
 
 1. src/back/core/graphdb/lakebase/LakebaseFlatStore.py
-   Replace VALUES join in find_subjects_by_patterns() with suffix-length
-   buckets using RIGHT(subject, k) = ANY(ARRAY[...]) and batched arrays.
+   Replace VALUES join in find_subjects_by_patterns() with a single OR-of-ANY
+   query across suffix-length buckets.
 
 2. src/back/core/graphdb/lakebase/LakebaseFlatStore.py
    Add defaultdict-based grouping by suffix length and keep generic LIKE
    fallback only for non-``%/<id>`` patterns.
-
-3. src/back/core/graphdb/lakebase/LakebaseFlatStore.py
-   Tune _ALIAS_VALUES_BATCH from 1000 to 500 for safer statement size.
 
 Modified files:
 - src/back/core/graphdb/lakebase/LakebaseFlatStore.py

--- a/changelogs/2026-07-08.log
+++ b/changelogs/2026-07-08.log
@@ -1,0 +1,106 @@
+## Add managed-sync index hook for Lakebase _sync tables
+
+Context: In managed_synced mode, Lakeflow creates the Postgres _sync table.
+The app already created indexes for app-managed tables and companion tables,
+but there was no explicit index ensure step for Lakeflow-created _sync tables.
+This could leave BFS joins slower than expected after sync materialization or
+physical table recreation.
+
+Changes:
+
+1. src/back/core/graphdb/lakebase/_companion_ddl.py
+   Add ensure_graph_indexes(cur, table_ref) helper that creates idempotent
+   graph indexes (subject,predicate), (predicate,object), (object,predicate)
+   for bare or schema-qualified table references.
+
+2. src/back/core/graphdb/lakebase/_companion_ddl.py
+   Refactor ensure_synced() and ensure_companion() to call
+   ensure_graph_indexes() instead of duplicating index DDL loops.
+
+3. src/back/core/graphdb/lakebase/LakebaseFlatStore.py
+   In ensure_synced_union_view(), call ensure_graph_indexes() for the visible
+   _sync table before creating the union view. Guard with warning-only fallback
+   so ownership/permission mismatches do not block build completion.
+
+Modified files:
+- src/back/core/graphdb/lakebase/_companion_ddl.py
+- src/back/core/graphdb/lakebase/LakebaseFlatStore.py
+
+Tests: skipped — not run in this environment
+
+---
+
+## Refine URI alias expansion with bucketed ANY probes
+
+Context: Follow-up benchmarking on production-like Lakebase data showed the
+VALUES-join alias expansion path was slower than OR-LIKE under high pattern
+counts. A bucketed fixed-length suffix probe strategy completed large sets
+reliably (including ~1300 IDs) with materially lower latency.
+
+Changes:
+
+1. src/back/core/graphdb/lakebase/LakebaseFlatStore.py
+   Replace VALUES join in find_subjects_by_patterns() with suffix-length
+   buckets using RIGHT(subject, k) = ANY(ARRAY[...]) and batched arrays.
+
+2. src/back/core/graphdb/lakebase/LakebaseFlatStore.py
+   Add defaultdict-based grouping by suffix length and keep generic LIKE
+   fallback only for non-``%/<id>`` patterns.
+
+3. src/back/core/graphdb/lakebase/LakebaseFlatStore.py
+   Tune _ALIAS_VALUES_BATCH from 1000 to 500 for safer statement size.
+
+Modified files:
+- src/back/core/graphdb/lakebase/LakebaseFlatStore.py
+
+Tests: skipped — not run in this environment
+
+---
+
+## Optimize describe_entity alias expansion on large ID sets
+
+Context: Chat/describe_entity generated slow SQL with 1000+ OR-LIKE suffix
+predicates (``subject LIKE '%/WTG:...'``), causing long-running statements and
+timeouts despite table indexing.
+
+Changes:
+
+1. src/back/core/graphdb/lakebase/LakebaseFlatStore.py
+   Add Lakebase override for find_subjects_by_patterns() that uses a set-based
+   VALUES join for the common ``%/<local-id>`` suffix pattern instead of one
+   giant OR chain. Keep fallback path for generic patterns.
+
+2. src/back/objects/digitaltwin/DigitalTwin.py
+   Add alias-expansion guardrail: skip URI alias expansion when local-id set
+   size exceeds 400 to keep chat responses responsive under high fan-out.
+
+Modified files:
+- src/back/core/graphdb/lakebase/LakebaseFlatStore.py
+- src/back/objects/digitaltwin/DigitalTwin.py
+
+Tests: skipped — not run in this environment
+
+---
+
+## Harden managed-sync indexing for partitioned _sync tables
+
+Context: Lakebase query logs showed managed sync using partition lifecycle
+operations (including DETACH PARTITION) on the _sync table. This means index
+state can drift at the leaf-partition level even when parent-level index DDL
+exists. To keep BFS and neighbour traversals stable after partition churn,
+index ensure needs to cover child partitions too.
+
+Changes:
+
+1. src/back/core/graphdb/lakebase/_companion_ddl.py
+   Extend ensure_graph_indexes() to discover leaf partitions via pg_inherits
+   and apply idempotent indexes to each child table.
+
+2. src/back/core/graphdb/lakebase/_companion_ddl.py
+   Add deterministic partition index naming helper using md5 token suffix to
+   avoid collisions under PostgreSQL's 63-char identifier cap.
+
+Modified files:
+- src/back/core/graphdb/lakebase/_companion_ddl.py
+
+Tests: skipped — not run in this environment

--- a/changelogs/2026-07-08.log
+++ b/changelogs/2026-07-08.log
@@ -1,35 +1,3 @@
-## Add managed-sync index hook for Lakebase _sync tables
-
-Context: In managed_synced mode, Lakeflow creates the Postgres _sync table.
-The app already created indexes for app-managed tables and companion tables,
-but there was no explicit index ensure step for Lakeflow-created _sync tables.
-This could leave BFS joins slower than expected after sync materialization or
-physical table recreation.
-
-Changes:
-
-1. src/back/core/graphdb/lakebase/_companion_ddl.py
-   Add ensure_graph_indexes(cur, table_ref) helper that creates idempotent
-   graph indexes (subject,predicate), (predicate,object), (object,predicate)
-   for bare or schema-qualified table references.
-
-2. src/back/core/graphdb/lakebase/_companion_ddl.py
-   Refactor ensure_synced() and ensure_companion() to call
-   ensure_graph_indexes() instead of duplicating index DDL loops.
-
-3. src/back/core/graphdb/lakebase/LakebaseFlatStore.py
-   In ensure_synced_union_view(), call ensure_graph_indexes() for the visible
-   _sync table before creating the union view. Guard with warning-only fallback
-   so ownership/permission mismatches do not block build completion.
-
-Modified files:
-- src/back/core/graphdb/lakebase/_companion_ddl.py
-- src/back/core/graphdb/lakebase/LakebaseFlatStore.py
-
-Tests: skipped — not run in this environment
-
----
-
 ## Refine URI alias expansion with OR-of-ANY probes
 
 Context: Follow-up benchmarking on production-like Lakebase data showed the
@@ -76,30 +44,5 @@ Changes:
 Modified files:
 - src/back/core/graphdb/lakebase/LakebaseFlatStore.py
 - src/back/objects/digitaltwin/DigitalTwin.py
-
-Tests: skipped — not run in this environment
-
----
-
-## Harden managed-sync indexing for partitioned _sync tables
-
-Context: Lakebase query logs showed managed sync using partition lifecycle
-operations (including DETACH PARTITION) on the _sync table. This means index
-state can drift at the leaf-partition level even when parent-level index DDL
-exists. To keep BFS and neighbour traversals stable after partition churn,
-index ensure needs to cover child partitions too.
-
-Changes:
-
-1. src/back/core/graphdb/lakebase/_companion_ddl.py
-   Extend ensure_graph_indexes() to discover leaf partitions via pg_inherits
-   and apply idempotent indexes to each child table.
-
-2. src/back/core/graphdb/lakebase/_companion_ddl.py
-   Add deterministic partition index naming helper using md5 token suffix to
-   avoid collisions under PostgreSQL's 63-char identifier cap.
-
-Modified files:
-- src/back/core/graphdb/lakebase/_companion_ddl.py
 
 Tests: skipped — not run in this environment

--- a/src/back/core/graphdb/lakebase/LakebaseFlatStore.py
+++ b/src/back/core/graphdb/lakebase/LakebaseFlatStore.py
@@ -41,9 +41,6 @@ _COPY_DELETE_TEMP = "_ob_del_stage"
 SYNC_MODE_APP = "app_managed"
 SYNC_MODE_MANAGED = "managed_synced"
 
-# Cap ARRAY payload size used by alias-expansion suffix probes.
-_ALIAS_VALUES_BATCH = 500
-
 
 class LakebaseFlatStore(LakebaseBase):
     """Flat-model triple store on Lakebase Postgres.
@@ -378,8 +375,10 @@ class LakebaseFlatStore(LakebaseBase):
         performs poorly and can hit statement timeouts.
 
         For fixed suffix patterns (``%/<id>``), group IDs by suffix length and
-        issue ``RIGHT(subject, k) = ANY(ARRAY[...])`` probes. This scales with
-        distinct suffix lengths (typically 1-3), not with total pattern count.
+        build a single SQL statement with one ``RIGHT(subject, k) = ANY(...)``
+        clause per distinct suffix length. This scales with distinct suffix
+        lengths (typically 1-3), not with total pattern count, while keeping
+        the lookup to a single round-trip.
         """
         if not like_patterns:
             return set()
@@ -402,17 +401,21 @@ class LakebaseFlatStore(LakebaseBase):
 
         out: set[str] = set()
 
-        for suffix_len, ids in by_suffix_len.items():
-            uniq_ids = sorted({i for i in ids if i})
-            for i in range(0, len(uniq_ids), _ALIAS_VALUES_BATCH):
-                chunk = uniq_ids[i : i + _ALIAS_VALUES_BATCH]
-                array_lit = ", ".join(f"'/{self._sql_escape(v)}'" for v in chunk)
-                sql = (
-                    f"SELECT DISTINCT subject FROM {rel} "
-                    f"WHERE RIGHT(subject, {suffix_len}) = ANY(ARRAY[{array_lit}])"
+        if by_suffix_len:
+            or_clauses = [
+                "RIGHT(subject, {}) = ANY(ARRAY[{}])".format(
+                    suffix_len,
+                    ", ".join(
+                        f"'/{self._sql_escape(v)}'"
+                        for v in sorted({value for value in ids if value})
+                    ),
                 )
-                rows = self.execute_query(sql) or []
-                out.update(r["subject"] for r in rows if r.get("subject"))
+                for suffix_len, ids in sorted(by_suffix_len.items())
+            ]
+            rows = self.execute_query(
+                f"SELECT DISTINCT subject FROM {rel} WHERE {' OR '.join(or_clauses)}"
+            ) or []
+            out.update(r["subject"] for r in rows if r.get("subject"))
 
         if generic_patterns:
             like_clauses = " OR ".join(

--- a/src/back/core/graphdb/lakebase/LakebaseFlatStore.py
+++ b/src/back/core/graphdb/lakebase/LakebaseFlatStore.py
@@ -17,6 +17,7 @@ Two operating modes are supported:
 
 from __future__ import annotations
 
+from collections import defaultdict
 from contextlib import contextmanager
 from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Tuple
 
@@ -39,6 +40,9 @@ _COPY_DELETE_TEMP = "_ob_del_stage"
 
 SYNC_MODE_APP = "app_managed"
 SYNC_MODE_MANAGED = "managed_synced"
+
+# Cap ARRAY payload size used by alias-expansion suffix probes.
+_ALIAS_VALUES_BATCH = 500
 
 
 class LakebaseFlatStore(LakebaseBase):
@@ -363,6 +367,62 @@ class LakebaseFlatStore(LakebaseBase):
                 if cur.description:
                     return [dict(row) for row in cur.fetchall()]
                 return []
+
+    def find_subjects_by_patterns(
+        self, table_name: str, like_patterns: List[str]
+    ) -> set[str]:
+        """Optimized alias expansion for Lakebase Postgres.
+
+        ``describe_entity`` may pass hundreds or thousands of ``%/<local-id>``
+        patterns when expanding URI aliases. Building one giant OR-LIKE chain
+        performs poorly and can hit statement timeouts.
+
+        For fixed suffix patterns (``%/<id>``), group IDs by suffix length and
+        issue ``RIGHT(subject, k) = ANY(ARRAY[...])`` probes. This scales with
+        distinct suffix lengths (typically 1-3), not with total pattern count.
+        """
+        if not like_patterns:
+            return set()
+
+        rel = self._sql_relation(table_name)
+        by_suffix_len: dict[int, list[str]] = defaultdict(list)
+        generic_patterns: list[str] = []
+
+        for raw in like_patterns:
+            p = (raw or "").strip()
+            if not p:
+                continue
+            # Fast-path only exact suffix patterns like "%/WTG:123".
+            if p.startswith("%/") and ("%" not in p[2:]) and ("_" not in p[2:]):
+                local_id = p[2:]
+                suffix_len = len(local_id) + 1
+                by_suffix_len[suffix_len].append(local_id)
+            else:
+                generic_patterns.append(p)
+
+        out: set[str] = set()
+
+        for suffix_len, ids in by_suffix_len.items():
+            uniq_ids = sorted({i for i in ids if i})
+            for i in range(0, len(uniq_ids), _ALIAS_VALUES_BATCH):
+                chunk = uniq_ids[i : i + _ALIAS_VALUES_BATCH]
+                array_lit = ", ".join(f"'/{self._sql_escape(v)}'" for v in chunk)
+                sql = (
+                    f"SELECT DISTINCT subject FROM {rel} "
+                    f"WHERE RIGHT(subject, {suffix_len}) = ANY(ARRAY[{array_lit}])"
+                )
+                rows = self.execute_query(sql) or []
+                out.update(r["subject"] for r in rows if r.get("subject"))
+
+        if generic_patterns:
+            like_clauses = " OR ".join(
+                f"subject LIKE '{self._sql_escape(p)}'" for p in generic_patterns
+            )
+            sql = f"SELECT DISTINCT subject FROM {rel} WHERE {like_clauses}"
+            rows = self.execute_query(sql) or []
+            out.update(r["subject"] for r in rows if r.get("subject"))
+
+        return out
 
     def create_table(self, table_name: str) -> None:
         validate_table_name(table_name)


### PR DESCRIPTION
<!--
PR Template — Cursor-Native Superpowers (CNS) methodology
See docs/PR_REVIEW_CHECKLIST.md for the reviewer's pass.
-->

## Summary

Optimize describe_entity alias expansion on large ID sets

## Linked Issue / milestone

## Type of change

- [ ] feat — new feature
- [ ] fix — bug fix
- [ ] docs — documentation only
- [ ] refactor — no behaviour change
- [ ] test — tests only
- [x] perf — perf improvement
- [ ] ci / build / chore — tooling

## Author checklist

- [x] Conventional Commit PR title (`<type>(<scope>): <subject>`).
- [x] `changelogs/<today>.log` updated with title + context + numbered changes + files + test result.
- [ ] Tests added or modified for every behaviour change.
- [ ] `uv run pytest tests/<scope>/` green locally.
- [ ] `pre-commit run --all-files` clean (or skipped hooks documented).
- [ ] If `src/agents/**` or any MLflow-traced LLM path changed:
  - [ ] `SPEC.md` present in `.planning/<slug>/`.
  - [ ] `tests/eval/datasets/<agent>/dataset.jsonl` has ≥20 examples (new) or ≥10 (change).
  - [ ] MLflow eval run URI in PR body below.
  - [ ] Judge score ≥ baseline + delta, or explicit waiver here.
- [ ] If `src/mcp-server/**` changed: `uv run pytest tests/mcp/ -m mcp` green.
- [ ] No `gsd-*` references re-introduced.

## MLflow eval run

<!-- For agent PRs only. Paste the run URI: -->
<!-- https://<workspace>.databricks.com/ml/experiments/<id>/runs/<run-id> -->

## Test plan

Changes benchmarked directly against lakebase.
Validated by deploying and observing working as intended.
Need reviewer to execute tests, no local dev environment.

- [ ] `uv run pytest tests/ -m "not e2e and not property and not eval" --cov-fail-under=90`
- [ ] Per-package coverage thresholds (`scripts/check_coverage.py`) green for touched packages.
- [ ] If new MCP tool: `uv run pytest tests/mcp/integration/test_tool_schemas.py` includes it.

## Reviewer hint

See `docs/PR_REVIEW_CHECKLIST.md`. Numbered items map 1:1 to comments — `#3: missing OntoBricksError subclass for new condition` is more useful than "fix error handling".
