### PR TITLE
fix(scripts): make setup-lakebase.sh work with current Databricks CLI

### DIFF
--- a/changelogs/v0.6.1/bevdam_2026-07-13.log
+++ b/changelogs/v0.6.1/bevdam_2026-07-13.log
@@ -1,0 +1,48 @@
+# fix(scripts): setup-lakebase.sh compatibility with current Databricks CLI
+
+## Context
+
+Running `scripts/setup-lakebase.sh` with a current Databricks CLI fails
+silently (exit 1, no output). Three stale assumptions about CLI/API output
+formats had accumulated:
+
+1. `databricks auth env` now prints JSON (`{"env": {…}}`) instead of
+   `export KEY="…"` lines, so the `_cfg` helper resolved empty host/token.
+   Worse, the bare `grep` in `_cfg` tripped `set -o pipefail`, aborting the
+   script before the diagnostic guard could print anything.
+2. OAuth profiles (`auth_type=databricks-cli`, the default since PATs were
+   de-emphasised) expose no `DATABRICKS_TOKEN` in `auth env` at all — a
+   token must be minted via `databricks auth token`.
+3. `databricks postgres list-databases` now prints a bare JSON array rather
+   than `{"databases": […]}`, so existing databases were never detected and
+   the script attempted duplicate creation. The creation fallback payload
+   (`{"name": …}`) was also stale: the databases API now requires
+   `{"spec": {"postgres_database": …, "role": "projects/…/roles/…"}}`.
+
+## Changes
+
+1. `scripts/setup-lakebase.sh` — `_cfg` now parses both the JSON and legacy
+   `export`-line formats of `databricks auth env`, and always exits 0 so the
+   empty-value guard is reached and fails loudly.
+2. `scripts/setup-lakebase.sh` — when `auth env` yields no token (OAuth
+   profiles), mint a short-lived access token via `databricks auth token`.
+3. `scripts/setup-lakebase.sh` — database/endpoint/role list parsers accept
+   both bare-array and wrapped-object JSON shapes.
+4. `scripts/setup-lakebase.sh` — database creation now resolves the branch's
+   first Postgres role and posts the current
+   `{"spec": {"postgres_database", "role"}}` payload; failures are fatal
+   with the API response logged instead of being swallowed.
+
+## Modified files
+
+- scripts/setup-lakebase.sh
+
+## Test result
+
+`uv run pytest -q -m "not scenario"` — 2993 passed, 275 skipped,
+5 deselected in 121.97s.
+
+Live verification against an AWS workspace (CLI v0.250+, OAuth
+profile): fresh-provision path validated piecewise via the same API
+calls (instance + database created); idempotent re-run of the fixed
+script detects the existing instance and database and exits 0.

--- a/scripts/setup-lakebase.sh
+++ b/scripts/setup-lakebase.sh
@@ -76,13 +76,33 @@ _err() { echo "[setup-lakebase] ERR $*" >&2; exit 1; }
 _dry() { echo "[setup-lakebase] DRY $*"; }
 
 # ── Resolve Databricks host + token from CLI config ──────────────────────────
+# `databricks auth env` prints JSON on current CLIs and `export KEY="…"`
+# lines on older ones — handle both. Always exits 0 so the empty-value
+# guard below is reached (a bare grep would trip `set -o pipefail` and
+# abort the script before it can print a diagnostic).
 _cfg() {
-  databricks auth env --profile "$PROFILE" 2>/dev/null \
-    | grep "^export $1=" | sed "s/^export $1=\"//;s/\"$//"
+  databricks auth env --profile "$PROFILE" 2>/dev/null | python3 -c "
+import sys, json, re
+raw = sys.stdin.read()
+try:
+    print(json.loads(raw).get('env', {}).get(sys.argv[1], ''))
+except ValueError:
+    m = re.search(r'^export %s=\"(.*)\"$' % re.escape(sys.argv[1]), raw, re.M)
+    print(m.group(1) if m else '')
+" "$1"
 }
 
 HOST=$(_cfg DATABRICKS_HOST)
 TOKEN=$(_cfg DATABRICKS_TOKEN)
+
+# OAuth profiles (auth_type=databricks-cli) expose no DATABRICKS_TOKEN in
+# `auth env` — mint a short-lived OAuth access token instead.
+if [[ -z "$TOKEN" ]]; then
+  TOKEN=$(databricks auth token --profile "$PROFILE" 2>/dev/null | python3 -c "
+import sys, json
+print(json.load(sys.stdin).get('access_token', ''))
+" 2>/dev/null || true)
+fi
 
 [[ -z "$HOST" || -z "$TOKEN" ]] && \
   _err "Could not resolve DATABRICKS_HOST / DATABRICKS_TOKEN from profile '$PROFILE'."
@@ -152,7 +172,7 @@ EP_JSON=$(curl -sf "$HOST/api/2.0/postgres/projects/$NAME/branches/$BRANCH/endpo
 EP_HOST=$(echo "$EP_JSON" | python3 -c "
 import sys, json
 data = json.load(sys.stdin)
-eps = data.get('endpoints', [])
+eps = data if isinstance(data, list) else (data or {}).get('endpoints', [])
 for ep in eps:
     st = ep.get('status', {})
     if st.get('state') in ('EP_STATE_ACTIVE', 'AVAILABLE', None):
@@ -174,7 +194,8 @@ DB_LIST=$(databricks postgres list-databases "projects/$NAME/branches/$BRANCH" \
 DB_SEGMENT=$(echo "$DB_LIST" | python3 -c "
 import sys, json
 data = json.load(sys.stdin)
-dbs = data.get('databases', [])
+# Current CLIs print a bare JSON array; older ones wrap it in {'databases': […]}.
+dbs = data if isinstance(data, list) else (data or {}).get('databases', [])
 for db in dbs:
     status = db.get('status', {})
     pg_db  = status.get('postgres_database', '')
@@ -188,19 +209,26 @@ if [[ -n "$DB_SEGMENT" ]]; then
   _ok "Database '$DATABASE' already exists: segment='$DB_SEGMENT'"
 else
   _log "Creating Postgres database '$DATABASE' inside '$NAME/$BRANCH' …"
-  CREATE_OUT=$(databricks postgres create-database \
-    "projects/$NAME/branches/$BRANCH" \
-    --name "$DATABASE" \
-    --profile "$PROFILE" -o json 2>&1) || {
-      _log "  (create-database failed — database may already exist or CLI command unavailable)"
-      _log "  Raw output: $CREATE_OUT"
-      _log "  Falling back to API …"
-      DB_API_OUT=$(curl -sf -X POST \
-        "$HOST/api/2.0/postgres/projects/$NAME/branches/$BRANCH/databases" \
-        -H "Authorization: Bearer $TOKEN" \
-        -H "Content-Type: application/json" \
-        -d "{\"name\":\"$DATABASE\"}" 2>&1) || true
+  # The databases API requires spec.postgres_database plus spec.role in
+  # full resource-path form; resolve the branch's first role (the
+  # creator's) rather than hardcoding one.
+  ROLE_PATH=$(curl -sf "$HOST/api/2.0/postgres/projects/$NAME/branches/$BRANCH/roles" \
+    -H "Authorization: Bearer $TOKEN" 2>/dev/null | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+roles = data if isinstance(data, list) else (data or {}).get('roles', [])
+print(roles[0]['name'] if roles else '')
+" 2>/dev/null || true)
+  [[ -z "$ROLE_PATH" ]] && \
+    _err "Could not resolve a Postgres role on '$NAME/$BRANCH' to own '$DATABASE'."
+
+  DB_API_OUT=$(curl -sf -X POST \
+    "$HOST/api/2.0/postgres/projects/$NAME/branches/$BRANCH/databases" \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "{\"spec\":{\"postgres_database\":\"$DATABASE\",\"role\":\"$ROLE_PATH\"}}" 2>&1) || {
       _log "  API output: $DB_API_OUT"
+      _err "Failed to create database '$DATABASE' on '$NAME/$BRANCH'."
     }
 
   # Re-list to get the db-* segment
@@ -210,7 +238,8 @@ else
   DB_SEGMENT=$(echo "$DB_LIST" | python3 -c "
 import sys, json
 data = json.load(sys.stdin)
-for db in data.get('databases', []):
+dbs = data if isinstance(data, list) else (data or {}).get('databases', [])
+for db in dbs:
     pg_db = db.get('status', {}).get('postgres_database', '')
     seg   = db.get('name','').split('/')[-1]
     if pg_db == sys.argv[1] or seg == sys.argv[1]:


### PR DESCRIPTION
## Summary

`scripts/setup-lakebase.sh` fails silently (exit 1, no output) with current Databricks CLIs: `auth env` moved to JSON output, OAuth profiles no longer expose a PAT there at all, `list-databases` now prints a bare JSON array, and the databases API requires a `spec.postgres_database`/`spec.role` payload. This PR makes the script work with both old and new CLI output formats, mints an OAuth access token when no PAT is available, restores idempotency (existing instances/databases are detected again), and makes auth/creation failures fail loudly instead of silently.

## Linked Issue / milestone

Closes #117.

## Plan

n/a — single-file script fix, no architectural change.

## Type of change

- [ ] feat — new feature
- [x] fix — bug fix
- [ ] docs — documentation only
- [ ] refactor — no behaviour change
- [ ] test — tests only
- [ ] perf — perf improvement
- [ ] ci / build / chore — tooling

## Author checklist

- [x] Conventional Commit PR title (`<type>(<scope>): <subject>`).
- [x] `changelogs/v0.6.1/bevdam_2026-07-13.log` updated with title + context + numbered changes + files + test result.
- [ ] Tests added or modified for every behaviour change — n/a: shell provisioning script, not covered by the pytest suite; verified live (below).
- [x] `uv run pytest -q -m "not scenario"` green locally (2993 passed, 275 skipped).
- [x] No `gsd-*` references re-introduced.
- [ ] `src/agents/**` / MLflow-traced LLM paths — untouched.
- [ ] `src/mcp-server/**` — untouched.

## MLflow eval run

n/a

## Test plan

- [x] `uv run pytest -q -m "not scenario"` — 2993 passed, 275 skipped, 5 deselected.
- [x] Live verification on an AWS workspace with CLI v0.250+ (OAuth profile): fresh-provision path validated via the same API calls the script now issues (instance + database created); idempotent re-run of the fixed script detects the existing instance and database and exits 0 with the summary box.
- [x] `bash -n` syntax check.

## Reviewer hint

All four fixes are in `scripts/setup-lakebase.sh` and are independent: (1) `_cfg` JSON+legacy parsing, (2) `auth token` fallback for OAuth profiles, (3) tolerant list parsers (bare array vs wrapped object), (4) current databases-API payload with role resolution. The changelog entry walks them in the same order.