### PR TITLE
Release v0.6.2

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,12 +10,16 @@ Thank you to everyone who has contributed to OntoBricks!
 | Dermot Smyth | [@dermotsmyth-db](https://github.com/dermotsmyth-db) | Contributor |
 | Hugues Journeau | [@hourdays](https://github.com/hourdays) | Contributor |
 | Eric Poilvet | [@epoilvet](https://github.com/epoilvet) | Contributor |
+| Fiifi Botchway | [@FiifiB](https://github.com/FiifiB) | Contributor |
+
 
 ## Community Contributors
 
 | Name | GitHub | Contribution |
 |------|--------|--------------|
 | Andreas Niehaus | [@a-niehaus](https://github.com/a-niehaus) | Fix for Claude serving endpoints returning list-style `message.content` ([#107](https://github.com/databrickslabs/ontobricks/issues/107), [#109](https://github.com/databrickslabs/ontobricks/pull/109)) |
+| Ulrik Møller | [@ulsmo](https://github.com/ulsmo) | Contributor |
+| Mitul | [@kmitul](https://github.com/kmitul) | Contributor |
 
 ## How to Contribute
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,6 +11,12 @@ Thank you to everyone who has contributed to OntoBricks!
 | Hugues Journeau | [@hourdays](https://github.com/hourdays) | Contributor |
 | Eric Poilvet | [@epoilvet](https://github.com/epoilvet) | Contributor |
 
+## Community Contributors
+
+| Name | GitHub | Contribution |
+|------|--------|--------------|
+| Andreas Niehaus | [@a-niehaus](https://github.com/a-niehaus) | Fix for Claude serving endpoints returning list-style `message.content` ([#107](https://github.com/databrickslabs/ontobricks/issues/107), [#109](https://github.com/databrickslabs/ontobricks/pull/109)) |
+
 ## How to Contribute
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on how to get involved.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,6 +10,7 @@ Thank you to everyone who has contributed to OntoBricks!
 | Dermot Smyth | [@dermotsmyth-db](https://github.com/dermotsmyth-db) | Contributor |
 | Hugues Journeau | [@hourdays](https://github.com/hourdays) | Contributor |
 | Eric Poilvet | [@epoilvet](https://github.com/epoilvet) | Contributor |
+| Brian Castelino | [@bcastelino](https://github.com/bcastelino) | Contributor |
 
 ## How to Contribute
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="src/front/static/global/img/ontobricks-icon.svg" alt="OntoBricks Logo" width="120" height="120">
 </p>
 
-<h1 align="center">OntoBricks 0.6.1</h1>
+<h1 align="center">OntoBricks 0.6.2</h1>
 
 <p align="center">
   <strong>Knowledge Graph Builder for Databricks</strong>

--- a/changelogs/v0.6.1/briancastelino_2026-07-08.log
+++ b/changelogs/v0.6.1/briancastelino_2026-07-08.log
@@ -1,0 +1,13 @@
+## Add regression test for KG filtering on non-DRAFT versions
+
+### Context
+While using the Knowledge Graph explorer, I ran into a `403` ("This version is PUBLISHED; set it back to DRAFT to edit") when filtering the graph on a locked version. On investigation, that bug was already fixed upstream in commit 9d9c120, which replaced the broad `/dtwin/sync/` entry in `_STATUS_GATE_EDIT_PATHS` with the explicit write paths `/dtwin/sync/start` and `/dtwin/sync/load`, so the read-only `POST /dtwin/sync/filter` is no longer status-gated. To guard against a future regression, I am adding an end-to-end middleware dispatch test that locks in the correct behaviour.
+
+### Changes
+1. `tests/units/auth/test_permission_middleware.py`: I added `test_kg_filter_allowed_on_non_draft`, an end-to-end middleware dispatch test verifying `POST /dtwin/sync/filter` is allowed on `PUBLISHED` and `IN-REVIEW` versions. This complements the existing function-level test `test_dtwin_non_gated_paths_remain_open` by exercising the full dispatch path.
+
+### Modified files
+- `tests/units/auth/test_permission_middleware.py`
+
+### Test results
+I ran `tests/units/auth/test_permission_middleware.py` and got 255 passed, including the new regression test.

--- a/changelogs/v0.6.2/benoitcayladbx_2026-07-09.log
+++ b/changelogs/v0.6.2/benoitcayladbx_2026-07-09.log
@@ -1,0 +1,21 @@
+## Fix: Claude serving endpoints — flatten list-style message content
+
+Context: Databricks Claude serving endpoints (`databricks-claude-*`) return
+`choices[0].message.content` as a list of content blocks instead of a plain
+string. `extract_message_content` passed that through, so downstream `.strip()`
+calls crashed (`'list' object has no attribute 'strip'`), breaking Ontology
+Wizard → Generate and Mapping → Auto-Map. Cherry-picked from community PR #109
+(author: [@a-niehaus](https://github.com/a-niehaus), fixes #107) for the 0.6.2
+release branch.
+
+### Changes
+
+1. `src/agents/engine_base.py`
+   - Flatten list content blocks to a single string in `extract_message_content`;
+     OpenAI/Gemini string responses unchanged.
+
+### Modified files
+
+- `src/agents/engine_base.py`
+
+Tests: `uv run pytest -q tests/units/agents/test_agent_engine_base.py` — 22 passed.

--- a/changelogs/v0.6.2/benoitcayladbx_2026-07-09.log
+++ b/changelogs/v0.6.2/benoitcayladbx_2026-07-09.log
@@ -19,3 +19,52 @@ release branch.
 - `src/agents/engine_base.py`
 
 Tests: `uv run pytest -q tests/units/agents/test_agent_engine_base.py` — 22 passed.
+
+## Fix: Lakebase sync fails on long literal objects (issue #108)
+
+Context: Knowledge Graph sync to Lakebase Postgres aborted when any mapped
+literal `object` exceeded the Postgres btree index limit (~2704 bytes). The
+composite `PRIMARY KEY (subject, predicate, object)` and secondary indexes on
+`object` could not index long text columns (messages, notes, descriptions).
+Users saw an opaque "Triple store sync failed" message.
+
+Changes:
+
+1. `src/back/core/graphdb/lakebase/_companion_ddl.py`
+   - Add `object_hash` generated column (`digest(object, 'sha256')`) and key
+     uniqueness on `(subject, predicate, object_hash)`; enable `pgcrypto`;
+     add `wrap_triple_view_sql_for_lakeflow` and `LAKEFLOW_SYNC_PRIMARY_KEY`.
+2. `src/back/core/graphdb/lakebase/LakebaseFlatStore.py`
+   - Catch btree index limit errors with actionable messages; warn on legacy
+     tables missing `object_hash`.
+3. `src/back/core/graphdb/lakebase/schema.sql`
+   - Update reference DDL to match the new layout.
+4. `src/back/objects/digitaltwin/_build_pipeline.py`
+   - Wrap managed-synced warehouse VIEW with `object_hash`; use hash PK for
+     Lakeflow; improve sync failure messages.
+5. `src/back/objects/registry/scheduler.py`
+   - Use `object_hash` in Lakeflow `primary_key_columns`.
+6. `docs/lakebase-graphdb.md`
+   - Document long literal support and rebuild requirement for legacy graphs.
+7. `releasereq/PLAN-lakebase-long-literal-pk.md`
+   - Implementation plan for issue #108.
+8. `tests/units/core/test_lakebase_flat_store.py`
+   - Assert new DDL; test index-limit error handling and view SQL wrapper.
+9. `tests/units/core/test_synced_table_manager.py`
+   - Update Lakeflow PK column expectations.
+10. `tests/units/dtwin/test_build_pipeline_streaming.py`
+    - Update managed-synced PK column expectations.
+
+Modified files:
+- `src/back/core/graphdb/lakebase/_companion_ddl.py`
+- `src/back/core/graphdb/lakebase/LakebaseFlatStore.py`
+- `src/back/core/graphdb/lakebase/schema.sql`
+- `src/back/objects/digitaltwin/_build_pipeline.py`
+- `src/back/objects/registry/scheduler.py`
+- `docs/lakebase-graphdb.md`
+- `releasereq/PLAN-lakebase-long-literal-pk.md`
+- `tests/units/core/test_lakebase_flat_store.py`
+- `tests/units/core/test_synced_table_manager.py`
+- `tests/units/dtwin/test_build_pipeline_streaming.py`
+
+Tests: `uv run pytest -q -m "not scenario"` → 2995 passed, 275 skipped in 28.50s

--- a/changelogs/v0.6.2/benoitcayladbx_2026-07-10.log
+++ b/changelogs/v0.6.2/benoitcayladbx_2026-07-10.log
@@ -46,4 +46,4 @@ Modified files:
 - `src/back/core/graphdb/lakebase/LakebaseFlatStore.py`
 - `tests/units/core/test_lakebase_flat_store.py`
 
-Tests: pending full suite run after merge to develop.
+Tests: `uv run pytest -q -m "not scenario"` → 3210 passed, 275 skipped in 27.44s.

--- a/changelogs/v0.6.2/benoitcayladbx_2026-07-10.log
+++ b/changelogs/v0.6.2/benoitcayladbx_2026-07-10.log
@@ -20,3 +20,30 @@ Modified files:
 - `tests/units/core/test_lakebase_flat_store.py`
 
 Tests: `uv run pytest -q tests/units/core/test_lakebase_flat_store.py::test_scheduled_view_sql_wraps_object_hash_for_managed_synced tests/units/core/test_lakebase_flat_store.py::test_wrap_triple_view_sql_for_lakeflow_adds_object_hash` → 2 passed.
+
+---
+
+## Fix: ensure graph indexes on Lakeflow-managed _sync tables (issue #112, PR #113)
+
+Context: In `managed_synced` mode, Lakeflow creates the Postgres `_sync` table.
+App-managed tables and companions already got graph lookup indexes at DDL time,
+but Lakeflow-owned `_sync` tables had no ensure step after snapshot materialization
+or physical recreation — BFS / neighbour traversals could degrade badly (issue #112).
+
+Changes:
+
+1. `src/back/core/graphdb/lakebase/_companion_ddl.py`
+   - Extract `ensure_graph_indexes()` from `_create_triple_table()` using
+     `_TRIPLE_TABLE_INDEXES` (`object_hash` layout).
+2. `src/back/core/graphdb/lakebase/LakebaseFlatStore.py`
+   - Call `ensure_graph_indexes()` in `ensure_synced_union_view()` before the
+     union view DDL; warning-only fallback on permission/ownership errors.
+3. `tests/units/core/test_lakebase_flat_store.py`
+   - Regression test asserting three index DDL statements precede view creation.
+
+Modified files:
+- `src/back/core/graphdb/lakebase/_companion_ddl.py`
+- `src/back/core/graphdb/lakebase/LakebaseFlatStore.py`
+- `tests/units/core/test_lakebase_flat_store.py`
+
+Tests: pending full suite run after merge to develop.

--- a/changelogs/v0.6.2/benoitcayladbx_2026-07-10.log
+++ b/changelogs/v0.6.2/benoitcayladbx_2026-07-10.log
@@ -1,0 +1,22 @@
+## Fix: scheduled managed_synced builds emit object_hash in warehouse VIEW (issue #108)
+
+Context: The object_hash primary-key fix for long literal objects (#108) wrapped
+the Delta VIEW in the interactive DT build pipeline but not in the registry
+scheduler path. Scheduled managed_synced builds therefore created a VIEW without
+`object_hash` while Lakeflow expected `primary_key_columns = [subject, predicate,
+object_hash]`, breaking scheduled KG rebuilds on Lakebase.
+
+Changes:
+
+1. `src/back/objects/registry/scheduler.py`
+   - Resolve the graph store before VIEW creation; add
+     `_view_sql_for_graph_store` to wrap SQL with `object_hash` when
+     `managed_synced` is active (mirrors `_BuildPipeline._create_view`).
+2. `tests/units/core/test_lakebase_flat_store.py`
+   - Regression test for `_view_sql_for_graph_store` managed vs app_managed.
+
+Modified files:
+- `src/back/objects/registry/scheduler.py`
+- `tests/units/core/test_lakebase_flat_store.py`
+
+Tests: `uv run pytest -q tests/units/core/test_lakebase_flat_store.py::test_scheduled_view_sql_wraps_object_hash_for_managed_synced tests/units/core/test_lakebase_flat_store.py::test_wrap_triple_view_sql_for_lakeflow_adds_object_hash` → 2 passed.

--- a/changelogs/v0.6.2/benoitcayladbx_2026-07-10.log
+++ b/changelogs/v0.6.2/benoitcayladbx_2026-07-10.log
@@ -1,49 +1,20 @@
-## Fix: scheduled managed_synced builds emit object_hash in warehouse VIEW (issue #108)
+## Optimize Lakebase alias expansion for large local-id sets
 
-Context: The object_hash primary-key fix for long literal objects (#108) wrapped
-the Delta VIEW in the interactive DT build pipeline but not in the registry
-scheduler path. Scheduled managed_synced builds therefore created a VIEW without
-`object_hash` while Lakeflow expected `primary_key_columns = [subject, predicate,
-object_hash]`, breaking scheduled KG rebuilds on Lakebase.
+Context: `describe_entity` / Graph Chat alias expansion generated SQL with
+1000+ `OR LIKE '%/<local-id>'` predicates on Lakebase, causing long-running
+statements and timeouts. Incorporated from PR #115 review (supersedes external PR).
 
 Changes:
 
-1. `src/back/objects/registry/scheduler.py`
-   - Resolve the graph store before VIEW creation; add
-     `_view_sql_for_graph_store` to wrap SQL with `object_hash` when
-     `managed_synced` is active (mirrors `_BuildPipeline._create_view`).
-2. `tests/units/core/test_lakebase_flat_store.py`
-   - Regression test for `_view_sql_for_graph_store` managed vs app_managed.
+1. src/back/core/graphdb/lakebase/LakebaseFlatStore.py
+   Add `find_subjects_by_patterns()` override grouping `%/<id>` patterns by suffix
+   length into `RIGHT(subject, k) = ANY(ARRAY[...])` clauses (single round-trip).
+
+2. tests/units/core/test_lakebase_flat_store.py
+   Add unit tests for fast-path SQL shape, generic LIKE fallback, and escaping.
 
 Modified files:
-- `src/back/objects/registry/scheduler.py`
-- `tests/units/core/test_lakebase_flat_store.py`
+- src/back/core/graphdb/lakebase/LakebaseFlatStore.py
+- tests/units/core/test_lakebase_flat_store.py
 
-Tests: `uv run pytest -q tests/units/core/test_lakebase_flat_store.py::test_scheduled_view_sql_wraps_object_hash_for_managed_synced tests/units/core/test_lakebase_flat_store.py::test_wrap_triple_view_sql_for_lakeflow_adds_object_hash` → 2 passed.
-
----
-
-## Fix: ensure graph indexes on Lakeflow-managed _sync tables (issue #112, PR #113)
-
-Context: In `managed_synced` mode, Lakeflow creates the Postgres `_sync` table.
-App-managed tables and companions already got graph lookup indexes at DDL time,
-but Lakeflow-owned `_sync` tables had no ensure step after snapshot materialization
-or physical recreation — BFS / neighbour traversals could degrade badly (issue #112).
-
-Changes:
-
-1. `src/back/core/graphdb/lakebase/_companion_ddl.py`
-   - Extract `ensure_graph_indexes()` from `_create_triple_table()` using
-     `_TRIPLE_TABLE_INDEXES` (`object_hash` layout).
-2. `src/back/core/graphdb/lakebase/LakebaseFlatStore.py`
-   - Call `ensure_graph_indexes()` in `ensure_synced_union_view()` before the
-     union view DDL; warning-only fallback on permission/ownership errors.
-3. `tests/units/core/test_lakebase_flat_store.py`
-   - Regression test asserting three index DDL statements precede view creation.
-
-Modified files:
-- `src/back/core/graphdb/lakebase/_companion_ddl.py`
-- `src/back/core/graphdb/lakebase/LakebaseFlatStore.py`
-- `tests/units/core/test_lakebase_flat_store.py`
-
-Tests: `uv run pytest -q -m "not scenario"` → 3210 passed, 275 skipped in 27.44s.
+Tests: uv run pytest -q -m "not scenario" → 3003 passed, 275 skipped in 21.1s

--- a/changelogs/v0.6.2/benoitcayladbx_2026-07-12.log
+++ b/changelogs/v0.6.2/benoitcayladbx_2026-07-12.log
@@ -1,0 +1,22 @@
+## Move expired-session resume control into L2 subnav
+
+Context: When an editing session expired through inactivity, the app showed a
+yellow top banner with the expiry message and a "Resume editing" button. The
+banner competed with the navbar for vertical space; the control now lives in the
+second-level subnav beside Save, with the full message on hover.
+
+Changes:
+
+1. src/front/static/global/js/edit-lock.js
+   Replaced `renderExpiredBanner()` with `renderResumeEditingButton()` — injects
+   a yellow Resume editing button left of Save and shows the expiry text as a
+   Bootstrap tooltip.
+2. src/front/static/global/css/main.css
+   Added `.ob-subnav-resume-btn` styles (warning yellow, aligned with subnav
+   action buttons).
+
+Modified files:
+- src/front/static/global/js/edit-lock.js
+- src/front/static/global/css/main.css
+
+Tests: uv run pytest -q -m "not scenario" → 3003 passed, 275 skipped, 5 deselected, 23 warnings in 22.29s

--- a/changelogs/v0.6.2/benoitcayladbx_2026-07-12.log
+++ b/changelogs/v0.6.2/benoitcayladbx_2026-07-12.log
@@ -1,0 +1,22 @@
+## Move expired-session resume control into L2 subnav
+
+Context: When an editing session expired through inactivity, the app showed a
+yellow top banner with the expiry message and a "Resume editing" button. The
+banner competed with the navbar for vertical space; the control now lives in the
+second-level subnav beside Save, with the full message on hover.
+
+Changes:
+
+1. src/front/static/global/js/edit-lock.js
+   Replaced `renderExpiredBanner()` with `renderResumeEditingButton()` — injects
+   a yellow Resume editing button left of Save and shows the expiry text as a
+   Bootstrap tooltip.
+2. src/front/static/global/css/main.css
+   Added `.ob-subnav-resume-btn` styles (warning yellow, aligned with subnav
+   action buttons).
+
+Modified files:
+- src/front/static/global/js/edit-lock.js
+- src/front/static/global/css/main.css
+
+Tests: uv run pytest -q -m "not scenario" → 3227 passed, 275 skipped, 5 deselected, 23 warnings in 21.95s

--- a/changelogs/v0.6.2/benoitcayladbx_2026-07-14.log
+++ b/changelogs/v0.6.2/benoitcayladbx_2026-07-14.log
@@ -1,0 +1,36 @@
+## Isolate unit tests from developer .env Lakebase coordinates
+
+Context: Running the full pytest suite locally could hang at ~1% when a
+developer's ``.env`` exported ``LAKEBASE_*`` / ``PG*`` vars while pytest's
+autouse fixture forced a fake ``DATABRICKS_HOST``. Registry triplet probes
+then blocked on unreachable Lakebase auth. Two graph-engine config tests also
+failed when ``LAKEBASE_DATABASE`` leaked into env overlays.
+
+Changes:
+
+1. tests/conftest.py
+   Clear ``LAKEBASE_PROJECT``, ``LAKEBASE_BRANCH``, ``LAKEBASE_DATABASE``,
+   ``PGHOST``, and ``PGDATABASE`` in the autouse ``setup_test_env`` fixture so
+   unit tests stay hermetic.
+
+Modified files:
+- tests/conftest.py
+
+Tests: uv run pytest -q -m "not scenario" → 3003 passed, 275 skipped, 5 deselected, 23 warnings in 22.81s
+
+## Allow PAT-based deploy without forcing DEFAULT CLI profile
+
+Context: `make deploy` failed authentication when `DEFAULT_DATABRICKS_PROFILE` was
+empty but the bash `:-` fallback still forced the expired `DEFAULT` CLI profile,
+ignoring exported `DATABRICKS_TOKEN`.
+
+Changes:
+
+1. scripts/deploy.config.sh
+   Use `${DEFAULT_DATABRICKS_PROFILE-DEFAULT}` so an explicitly empty profile
+   (PAT deploy) is preserved instead of collapsing to `DEFAULT`.
+
+Modified files:
+- scripts/deploy.config.sh
+
+Tests: (same run as above — 3003 passed)

--- a/changelogs/v0.6.2/benoitcayladbx_2026-07-14.log
+++ b/changelogs/v0.6.2/benoitcayladbx_2026-07-14.log
@@ -34,3 +34,53 @@ Modified files:
 - scripts/deploy.config.sh
 
 Tests: (same run as above — 3003 passed)
+
+## Fix managed_synced VIEW missing object_hash at Lakeflow registration
+
+Context: Deployed KG builds failed with ``Could not register Lakebase synced
+table: column "object_hash" does not exist`` when Lakeflow validated the UC
+source VIEW. v0.6.2 keys synced tables on ``object_hash``, but the interactive
+build pipeline created the warehouse VIEW before opening the graph store, so
+mode resolution could disagree with the store and skip the Lakeflow wrapper.
+
+Changes:
+
+1. src/back/objects/digitaltwin/_build_pipeline.py
+   Open the graph store before VIEW creation; treat ``store.is_synced`` as the
+   source of truth for wrapping; refresh the source VIEW with ``object_hash``
+   immediately before ``SyncedTableManager.ensure``.
+2. tests/units/dtwin/test_build_pipeline_streaming.py
+   Cover store-driven VIEW wrapping and Lakeflow source refresh; set ``parts``
+   on bare pipeline fixtures.
+
+Modified files:
+- src/back/objects/digitaltwin/_build_pipeline.py
+- tests/units/dtwin/test_build_pipeline_streaming.py
+
+Tests: uv run pytest -q -m "not scenario" → 3005 passed, 275 skipped, 5 deselected, 23 warnings in 23.69s
+
+## Migrate legacy Lakebase companion tables to object_hash
+
+Context: KG builds still failed locally with ``column "object_hash" does not exist``
+even after the VIEW-wrap fix. Logs showed Lakeflow registration succeeded
+(``Synced table already exists — reusing``) and the failure was in
+``ensure_synced_companion``: pre-0.6.2 ``__app`` tables were left in place by
+``CREATE TABLE IF NOT EXISTS``, then ``ensure_graph_indexes`` tried to index
+``object_hash`` on a table that only had ``(subject, predicate, object)``.
+
+Changes:
+
+1. src/back/core/graphdb/lakebase/_companion_ddl.py
+   Add ``upgrade_legacy_triple_table_to_object_hash`` (add generated column,
+   drop legacy PK, re-key on ``object_hash``) before index creation.
+2. src/back/objects/digitaltwin/_build_pipeline.py
+   Split synced-table vs companion error handling for clearer failure messages.
+3. tests/units/core/test_lakebase_flat_store.py
+   Unit tests for legacy companion migration DDL.
+
+Modified files:
+- src/back/core/graphdb/lakebase/_companion_ddl.py
+- src/back/objects/digitaltwin/_build_pipeline.py
+- tests/units/core/test_lakebase_flat_store.py
+
+Tests: uv run pytest -q -m "not scenario" → 3007 passed, 275 skipped, 5 deselected, 23 warnings in 20.81s

--- a/docs/lakebase-graphdb.md
+++ b/docs/lakebase-graphdb.md
@@ -360,6 +360,22 @@ All SPARQL queries and graph traversal operations target the back-compat name
 3. `app_managed`: `DROP TABLE IF EXISTS g_<domain>_v<n>_sync` (sync table)
    `managed_synced`: `SyncedTableManager.delete(uc_name, purge_data=True)` — removes the UC synced-table registration and the underlying Postgres `_sync` table
 
+### 6.4 — Long literal objects (`object_hash`)
+
+Postgres btree indexes (including the composite primary key) cannot index TEXT
+values longer than ~2704 bytes. OntoBricks therefore stores the full `object`
+literal for reads/deletes but keys uniqueness on a generated `object_hash`
+column (`digest(object, 'sha256')` via the `pgcrypto` extension).
+
+- **`app_managed`**: `*_sync` and `*__app` tables are created with
+  `PRIMARY KEY (subject, predicate, object_hash)`.
+- **`managed_synced`**: the Delta warehouse VIEW exposes `object_hash`
+  (`sha2(object, 256)`) and Lakeflow uses
+  `primary_key_columns = [subject, predicate, object_hash]`.
+
+Graphs created before this layout need a **full Knowledge Graph rebuild** (drop
++ recreate) to pick up the new schema.
+
 ---
 
 ## 7. Scripts reference

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ontobricks"
-version = "0.6.1"
+version = "0.6.2"
 description = "Ontology Management Tool for Databricks"
 requires-python = ">=3.10"
 dependencies = [

--- a/releases/ReleaseNotes_V0.6.2.md
+++ b/releases/ReleaseNotes_V0.6.2.md
@@ -1,0 +1,190 @@
+# OntoBricks — Release Notes V0.6.2
+
+**Release date:** 2026-07-14
+**Type:** Patch release (v0.6.1 → v0.6.2)
+**Test status:** 3003 passed, 275 skipped, 5 deselected (`uv run pytest -q -m "not scenario"`).
+
+---
+
+## Summary
+
+v0.6.2 is a focused patch on top of v0.6.1. It hardens **Lakebase Knowledge Graph
+sync** for long literal values and Lakeflow-managed tables, fixes **Claude serving
+endpoint** responses that broke Ontology Wizard and Auto-Map, speeds up **Graph
+Explorer / Graph Chat** alias lookups on large graphs, and polishes the **edit-lock
+idle UX** (resume control moves into the L2 subnav). Developer ergonomics improve
+with **hermetic unit tests** (`.env` Lakebase vars no longer leak into pytest) and
+**PAT-based deploy** when the CLI profile is intentionally left empty.
+
+No breaking API changes. One **operational note** for existing Lakebase graphs: graphs
+built before the `object_hash` layout need a full KG rebuild (see Upgrade Notes).
+
+---
+
+## Highlights
+
+- **Lakebase long literals ([#108](https://github.com/databrickslabs/ontobricks/issues/108))** —
+  composite keys and Lakeflow sync use a generated `object_hash` so literal values
+  longer than the Postgres btree index limit no longer abort triple-store sync.
+- **Lakeflow graph indexes ([#112](https://github.com/databrickslabs/ontobricks/issues/112))** —
+  `ensure_synced_union_view` re-applies `object_hash` lookup indexes idempotently when
+  Lakeflow recreates `_sync` tables without secondary indexes.
+- **Claude serving endpoints ([#107](https://github.com/databrickslabs/ontobricks/issues/107), PR [#109](https://github.com/databrickslabs/ontobricks/pull/109))** —
+  flatten list-style `message.content` blocks from `databricks-claude-*` endpoints so
+  Ontology Wizard → Generate and Mapping → Auto-Map no longer crash on `.strip()`.
+- **Lakebase alias expansion performance (PR [#115](https://github.com/databrickslabs/ontobricks/pull/115))** —
+  group hundreds of `%/<local-id>` LIKE predicates into `RIGHT(subject, k) = ANY(...)`
+  clauses for fast Graph Chat / `describe_entity` alias resolution.
+- **Edit-lock idle UX** — when a session expires through inactivity, the yellow
+  **Resume editing** button sits left of **Save** in the L2 subnav; the full expiry
+  message is a hover tooltip (replaces the top-of-page banner).
+- **Developer hygiene** — pytest clears developer `LAKEBASE_*` / `PG*` env vars;
+  `make deploy` honours an explicitly empty `DEFAULT_DATABRICKS_PROFILE` for PAT auth.
+
+---
+
+## Bug Fixes
+
+### Lakebase sync for long literal objects ([#108](https://github.com/databrickslabs/ontobricks/issues/108))
+
+Knowledge Graph sync to Lakebase Postgres aborted when any mapped literal `object`
+exceeded the btree index limit (~2704 bytes). The composite primary key and secondary
+indexes on `object` could not index long text columns.
+
+- `src/back/core/graphdb/lakebase/_companion_ddl.py` — `object_hash` generated column
+  (`digest(object, 'sha256')`); uniqueness on `(subject, predicate, object_hash)`;
+  `pgcrypto`; Lakeflow view wrapper and `LAKEFLOW_SYNC_PRIMARY_KEY`.
+- `src/back/core/graphdb/lakebase/LakebaseFlatStore.py` — actionable errors on btree
+  limit failures; warn on legacy tables missing `object_hash`.
+- `src/back/objects/digitaltwin/_build_pipeline.py` — wrap managed-synced warehouse VIEW
+  with `object_hash`; hash PK for Lakeflow.
+- `src/back/objects/registry/scheduler.py` — Lakeflow `primary_key_columns` include
+  `object_hash`.
+- `docs/lakebase-graphdb.md` — document long-literal support and rebuild requirement.
+
+### Scheduled managed_synced VIEW builds ([#108](https://github.com/databrickslabs/ontobricks/issues/108))
+
+Scheduled registry builds created the warehouse VIEW without `object_hash` while Lakeflow
+keyed the synced table on that column.
+
+- `src/back/objects/digitaltwin/_build_pipeline.py` — resolve graph store before VIEW
+  creation; wrap SQL for `managed_synced`, matching the interactive DT build pipeline.
+
+### Lakeflow `_sync` table indexes ([#112](https://github.com/databrickslabs/ontobricks/issues/112))
+
+When Lakeflow recreates a `_sync` table, secondary indexes on `object_hash` were lost,
+degrading BFS / graph traversal performance.
+
+- `src/back/core/graphdb/lakebase/_companion_ddl.py` / `ensure_synced_union_view` —
+  idempotently re-apply graph lookup indexes after managed-synced rebuilds.
+
+### Claude serving endpoint content blocks ([#107](https://github.com/databrickslabs/ontobricks/issues/107))
+
+Databricks Claude serving endpoints return `choices[0].message.content` as a list of
+content blocks instead of a plain string.
+
+- `src/agents/engine_base.py` — `extract_message_content` flattens list blocks to a
+  single string (OpenAI/Gemini string responses unchanged).
+- Cherry-picked from community PR [#109](https://github.com/databrickslabs/ontobricks/pull/109)
+  (Andreas Niehaus).
+
+---
+
+## Enhancements
+
+### Lakebase alias expansion for large local-id sets (PR [#115](https://github.com/databrickslabs/ontobricks/pull/115))
+
+`describe_entity` / Graph Chat alias expansion previously generated SQL with 1000+
+`OR LIKE '%/<local-id>'` predicates, causing long-running statements and timeouts on
+Lakebase.
+
+- `src/back/core/graphdb/lakebase/LakebaseFlatStore.py` —
+  `find_subjects_by_patterns()` groups patterns by suffix length into
+  `RIGHT(subject, k) = ANY(ARRAY[...])` clauses (single round-trip).
+
+### Edit-lock — resume control in L2 subnav
+
+When an editing session expired through inactivity, a yellow top banner consumed
+vertical space above the navbar.
+
+- `src/front/static/global/js/edit-lock.js` — `renderResumeEditingButton()` injects a
+  yellow **Resume editing** button left of **Save**; expiry text is a Bootstrap tooltip.
+- `src/front/static/global/css/main.css` — `.ob-subnav-resume-btn` styles.
+
+The "another user is editing" viewer banner is unchanged.
+
+---
+
+## Deploy & Operations
+
+### PAT-based deploy (`deploy.config.sh`)
+
+`DEFAULT_DATABRICKS_PROFILE="${DEFAULT_DATABRICKS_PROFILE:-DEFAULT}"` treated an
+explicitly empty profile the same as unset, forcing the expired `DEFAULT` CLI profile
+even when `DATABRICKS_TOKEN` was exported.
+
+- `scripts/deploy.config.sh` — use `${DEFAULT_DATABRICKS_PROFILE-DEFAULT}` so
+  `DEFAULT_DATABRICKS_PROFILE= make deploy` uses PAT auth when the token is in the
+  environment.
+
+### Hermetic unit tests (`tests/conftest.py`)
+
+A developer's `.env` could export `LAKEBASE_*` / `PG*` coordinates while pytest's
+autouse fixture forced a fake `DATABRICKS_HOST`, causing Registry triplet probes to
+block the suite (~1% hang) and two graph-engine config tests to fail.
+
+- `tests/conftest.py` — clear `LAKEBASE_PROJECT`, `LAKEBASE_BRANCH`,
+  `LAKEBASE_DATABASE`, `PGHOST`, and `PGDATABASE` in `setup_test_env`.
+
+---
+
+## Upgrade Notes
+
+### Upgrading from v0.6.1
+
+Deploy the new app bundle as usual (`make deploy`). No new Lakebase **registry** schema
+tables are required for this release.
+
+**Knowledge Graph graphs on Lakebase:** if your companion triple-store tables were
+created before the `object_hash` layout, run a **full Knowledge Graph rebuild** on each
+affected domain version so sync keys and indexes match the new DDL. See
+`docs/lakebase-graphdb.md` §6.4.
+
+If you deploy with a Personal Access Token instead of a CLI OAuth profile, you can run:
+
+```bash
+export DATABRICKS_HOST=… DATABRICKS_TOKEN=…
+DEFAULT_DATABRICKS_PROFILE= make deploy
+```
+
+Optionally set `LAKEBASE_DATABASE_RESOURCE_SEGMENT=db-…` when the deploy preflight
+cannot auto-resolve the Lakebase database resource id.
+
+### Upgrading from v0.5.x or v0.6.0
+
+Upgrade through v0.6.1 first (see `releases/ReleaseNotes_V0.6.1.md`), then apply v0.6.2.
+
+---
+
+## Changes Summary
+
+| Area | Key files | Change type |
+|------|-----------|-------------|
+| Lakebase long literal PK | `_companion_ddl.py`, `LakebaseFlatStore.py`, `_build_pipeline.py`, `scheduler.py` | Fix |
+| Lakeflow `_sync` indexes | `_companion_ddl.py`, `ensure_synced_union_view` | Fix |
+| Claude endpoint content | `agents/engine_base.py` | Fix |
+| Lakebase alias expansion perf | `LakebaseFlatStore.py` | Enhancement |
+| Edit-lock idle UX | `edit-lock.js`, `main.css` | UX |
+| PAT deploy profile | `deploy.config.sh` | Enhancement |
+| Hermetic pytest env | `tests/conftest.py` | Fix |
+| Version | `pyproject.toml` | Bumped to `0.6.2` |
+
+---
+
+## What is NOT changed
+
+- External API contract — all `/api/v1/` endpoints are backward-compatible.
+- MCP tool contracts — no MCP tool signatures changed.
+- Registry Lakebase schema — no new collaboration / audit tables.
+- v0.6.0 / v0.6.1 features — collaboration, graph analytics, edit-lock lease,
+  audit trail, Switch modal fix, and all other capabilities remain intact.

--- a/releases/ReleaseNotes_V0.6.2.md
+++ b/releases/ReleaseNotes_V0.6.2.md
@@ -2,7 +2,7 @@
 
 **Release date:** 2026-07-14
 **Type:** Patch release (v0.6.1 → v0.6.2)
-**Test status:** 3003 passed, 275 skipped, 5 deselected (`uv run pytest -q -m "not scenario"`).
+**Test status:** 3007 passed, 275 skipped, 5 deselected (`uv run pytest -q -m "not scenario"`).
 
 ---
 
@@ -16,13 +16,18 @@ idle UX** (resume control moves into the L2 subnav). Developer ergonomics improv
 with **hermetic unit tests** (`.env` Lakebase vars no longer leak into pytest) and
 **PAT-based deploy** when the CLI profile is intentionally left empty.
 
-No breaking API changes. One **operational note** for existing Lakebase graphs: graphs
-built before the `object_hash` layout need a full KG rebuild (see Upgrade Notes).
+No breaking API changes. One **operational note** for existing Lakebase graphs: run a
+**full Knowledge Graph rebuild** after upgrading so companion tables migrate to the
+`object_hash` layout (automatic on build — see Upgrade Notes).
 
 ---
 
 ## Highlights
 
+- **Lakebase `object_hash` KG build fixes** — interactive managed_synced builds open
+  the graph store before VIEW creation, refresh the Lakeflow source VIEW with
+  `object_hash`, and auto-migrate legacy `__app` companion tables that still keyed
+  on full `object` text (fixes `column "object_hash" does not exist` on rebuild).
 - **Lakebase long literals ([#108](https://github.com/databrickslabs/ontobricks/issues/108))** —
   composite keys and Lakeflow sync use a generated `object_hash` so literal values
   longer than the Postgres btree index limit no longer abort triple-store sync.
@@ -62,13 +67,36 @@ indexes on `object` could not index long text columns.
   `object_hash`.
 - `docs/lakebase-graphdb.md` — document long-literal support and rebuild requirement.
 
+### Interactive managed_synced KG build (`object_hash`)
+
+KG builds on existing domains could fail with `Could not register Lakebase synced
+table: column "object_hash" does not exist` even when Lakeflow registration succeeded.
+Two root causes:
+
+1. **Warehouse VIEW** — the interactive build pipeline created the UC VIEW before
+   opening the graph store, so sync-mode resolution could skip the Lakeflow wrapper
+   that adds `object_hash` to the source VIEW.
+2. **Legacy companion table** — pre-0.6.2 `__app` tables were left in place by
+   `CREATE TABLE IF NOT EXISTS`; index DDL then referenced `object_hash` on a table
+   that still had primary key `(subject, predicate, object)`.
+
+- `src/back/objects/digitaltwin/_build_pipeline.py` — open graph store before VIEW
+  creation; treat `store.is_synced` as source of truth for wrapping; refresh source
+  VIEW with `object_hash` before `SyncedTableManager.ensure`; split companion vs
+  synced-table error messages.
+- `src/back/core/graphdb/lakebase/_companion_ddl.py` —
+  `upgrade_legacy_triple_table_to_object_hash()` migrates existing companions
+  (add generated column, drop legacy PK, re-key on `object_hash`) before indexes.
+- `tests/units/dtwin/test_build_pipeline_streaming.py`,
+  `tests/units/core/test_lakebase_flat_store.py` — regression coverage.
+
 ### Scheduled managed_synced VIEW builds ([#108](https://github.com/databrickslabs/ontobricks/issues/108))
 
 Scheduled registry builds created the warehouse VIEW without `object_hash` while Lakeflow
 keyed the synced table on that column.
 
-- `src/back/objects/digitaltwin/_build_pipeline.py` — resolve graph store before VIEW
-  creation; wrap SQL for `managed_synced`, matching the interactive DT build pipeline.
+- `src/back/objects/registry/scheduler.py` — resolve graph store before VIEW creation;
+  wrap SQL for `managed_synced` via `_view_sql_for_graph_store()`.
 
 ### Lakeflow `_sync` table indexes ([#112](https://github.com/databrickslabs/ontobricks/issues/112))
 
@@ -147,8 +175,9 @@ tables are required for this release.
 
 **Knowledge Graph graphs on Lakebase:** if your companion triple-store tables were
 created before the `object_hash` layout, run a **full Knowledge Graph rebuild** on each
-affected domain version so sync keys and indexes match the new DDL. See
-`docs/lakebase-graphdb.md` §6.4.
+affected domain version. v0.6.2 migrates legacy `__app` companions automatically during
+the build (adds `object_hash`, re-keys the PK, recreates indexes). No manual Postgres DDL
+is required. See `docs/lakebase-graphdb.md` §6.4.
 
 If you deploy with a Personal Access Token instead of a CLI OAuth profile, you can run:
 
@@ -171,6 +200,7 @@ Upgrade through v0.6.1 first (see `releases/ReleaseNotes_V0.6.1.md`), then apply
 | Area | Key files | Change type |
 |------|-----------|-------------|
 | Lakebase long literal PK | `_companion_ddl.py`, `LakebaseFlatStore.py`, `_build_pipeline.py`, `scheduler.py` | Fix |
+| `object_hash` KG build (VIEW + companion migration) | `_build_pipeline.py`, `_companion_ddl.py` | Fix |
 | Lakeflow `_sync` indexes | `_companion_ddl.py`, `ensure_synced_union_view` | Fix |
 | Claude endpoint content | `agents/engine_base.py` | Fix |
 | Lakebase alias expansion perf | `LakebaseFlatStore.py` | Enhancement |

--- a/scripts/deploy.config.sh
+++ b/scripts/deploy.config.sh
@@ -40,7 +40,7 @@ DEFAULT_APP_NAME="ontobricks-060"
 # Databricks CLI profile (`databricks auth profiles`). Leave empty to use
 # the CLI default profile. Exported as DATABRICKS_CONFIG_PROFILE for all
 # `databricks` invocations when this file is sourced (make deploy, bootstrap, …).
-DEFAULT_DATABRICKS_PROFILE="${DEFAULT_DATABRICKS_PROFILE:-DEFAULT}"
+DEFAULT_DATABRICKS_PROFILE="${DEFAULT_DATABRICKS_PROFILE-DEFAULT}"
 
 # SQL Warehouse
 DEFAULT_WAREHOUSE_ID="d2096aa075ad44a3"

--- a/src/agents/engine_base.py
+++ b/src/agents/engine_base.py
@@ -184,7 +184,13 @@ def extract_message_content(llm_response: dict) -> str:
     """Extract text content from an OpenAI-style or predictions-style LLM response."""
     choices = llm_response.get("choices", [])
     if choices:
-        return choices[0].get("message", {}).get("content", "") or ""
+        content = choices[0].get("message", {}).get("content") or ""
+        # Claude endpoints return content as a list of blocks, not a string
+        if isinstance(content, list):
+            content = "".join(
+                b if isinstance(b, str) else b.get("text", "") for b in content
+            )
+        return content
     preds = llm_response.get("predictions", [])
     if preds:
         return preds[0] if isinstance(preds[0], str) else str(preds[0])

--- a/src/back/core/graphdb/lakebase/LakebaseFlatStore.py
+++ b/src/back/core/graphdb/lakebase/LakebaseFlatStore.py
@@ -17,8 +17,9 @@ Two operating modes are supported:
 
 from __future__ import annotations
 
+from collections import defaultdict
 from contextlib import contextmanager
-from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Tuple
+from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Set, Tuple
 
 from back.core.errors import InfrastructureError
 from back.core.graphdb.lakebase import _companion_ddl
@@ -433,6 +434,66 @@ class LakebaseFlatStore(LakebaseBase):
                 if cur.description:
                     return [dict(row) for row in cur.fetchall()]
                 return []
+
+    def find_subjects_by_patterns(
+        self, table_name: str, like_patterns: List[str]
+    ) -> Set[str]:
+        """Optimized alias expansion for Lakebase Postgres.
+
+        ``describe_entity`` may pass hundreds or thousands of ``%/<local-id>``
+        patterns when expanding URI aliases. Building one giant OR-LIKE chain
+        performs poorly and can hit statement timeouts.
+
+        For fixed suffix patterns (``%/<id>``), group IDs by suffix length and
+        build a single SQL statement with one ``RIGHT(subject, k) = ANY(...)``
+        clause per distinct suffix length. This scales with distinct suffix
+        lengths (typically 1-3), not with total pattern count, while keeping
+        the lookup to a single round-trip.
+        """
+        if not like_patterns:
+            return set()
+
+        rel = self._sql_relation(table_name)
+        by_suffix_len: dict[int, list[str]] = defaultdict(list)
+        generic_patterns: list[str] = []
+
+        for raw in like_patterns:
+            p = (raw or "").strip()
+            if not p:
+                continue
+            if p.startswith("%/") and ("%" not in p[2:]) and ("_" not in p[2:]):
+                local_id = p[2:]
+                suffix_len = len(local_id) + 1
+                by_suffix_len[suffix_len].append(local_id)
+            else:
+                generic_patterns.append(p)
+
+        out: set[str] = set()
+
+        if by_suffix_len:
+            or_clauses = []
+            for suffix_len, ids in sorted(by_suffix_len.items()):
+                array_literals = ", ".join(
+                    f"'/{self._sql_escape(v)}'"
+                    for v in sorted({value for value in ids if value})
+                )
+                or_clauses.append(
+                    f"RIGHT(subject, {suffix_len}) = ANY(ARRAY[{array_literals}])"
+                )
+            rows = self.execute_query(
+                f"SELECT DISTINCT subject FROM {rel} WHERE {' OR '.join(or_clauses)}"
+            ) or []
+            out.update(r["subject"] for r in rows if r.get("subject"))
+
+        if generic_patterns:
+            like_clauses = " OR ".join(
+                f"subject LIKE '{self._sql_escape(p)}'" for p in generic_patterns
+            )
+            sql = f"SELECT DISTINCT subject FROM {rel} WHERE {like_clauses}"
+            rows = self.execute_query(sql) or []
+            out.update(r["subject"] for r in rows if r.get("subject"))
+
+        return out
 
     def create_table(self, table_name: str) -> None:
         validate_table_name(table_name)

--- a/src/back/core/graphdb/lakebase/LakebaseFlatStore.py
+++ b/src/back/core/graphdb/lakebase/LakebaseFlatStore.py
@@ -37,8 +37,42 @@ _BULK_DELETE_THRESHOLD = 50
 _COPY_INSERT_TEMP = "_ob_copy_stage"
 _COPY_DELETE_TEMP = "_ob_del_stage"
 
+# Postgres btree version-4 index entry limit (bytes).
+_PG_BTREE_INDEX_MAX_BYTES = 2704
+
 SYNC_MODE_APP = "app_managed"
 SYNC_MODE_MANAGED = "managed_synced"
+
+
+def _is_index_row_size_error(exc: BaseException) -> bool:
+    msg = str(exc).lower()
+    if "index row size" in msg and "btree" in msg:
+        return True
+    return exc.__class__.__name__ == "ProgramLimitExceeded"
+
+
+def _long_literal_detail(batch: List[Dict[str, str]]) -> str:
+    worst = max(
+        batch,
+        key=lambda t: len((t.get("object") or "").encode("utf-8")),
+    )
+    obj_bytes = len((worst.get("object") or "").encode("utf-8"))
+    predicate = worst.get("predicate") or "?"
+    return f"predicate={predicate!r}, object_size={obj_bytes} bytes"
+
+
+def _reraise_lakebase_index_limit(
+    exc: BaseException, batch: List[Dict[str, str]]
+) -> None:
+    if not _is_index_row_size_error(exc):
+        raise exc
+    detail = _long_literal_detail(batch)
+    raise InfrastructureError(
+        "Lakebase triple insert failed: a literal object exceeds the Postgres "
+        f"btree index size limit ({detail}). Run a full Knowledge Graph rebuild "
+        "to apply the object_hash schema, or exclude very long text columns "
+        "from mapping."
+    ) from exc
 
 
 class LakebaseFlatStore(LakebaseBase):
@@ -346,6 +380,31 @@ class LakebaseFlatStore(LakebaseBase):
             f"ALTER TABLE {phy} ADD COLUMN IF NOT EXISTS datatype TEXT"
         )
         cur.execute(f"ALTER TABLE {phy} ADD COLUMN IF NOT EXISTS lang TEXT")
+        self._warn_legacy_object_pk(cur, phy)
+
+    @staticmethod
+    def _warn_legacy_object_pk(cur: Any, phy: str) -> None:
+        """Log when an existing table still keys on full ``object`` text."""
+        bare = phy.split(".")[-1].strip('"')
+        cur.execute(
+            """
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = ANY(current_schemas(false))
+              AND table_name = %s
+              AND column_name = 'object_hash'
+            LIMIT 1
+            """,
+            (bare,),
+        )
+        if cur.fetchone() is None:
+            logger.warning(
+                "Lakebase table %s uses the legacy PRIMARY KEY (subject, predicate, object) "
+                "and cannot store literal objects longer than %d bytes. "
+                "Run a full Knowledge Graph rebuild to migrate to object_hash.",
+                phy,
+                _PG_BTREE_INDEX_MAX_BYTES,
+            )
 
     @staticmethod
     def _require_pg():
@@ -473,33 +532,36 @@ class LakebaseFlatStore(LakebaseBase):
         """
         if not batch:
             return 0
-        with self._txn_cursor() as (_, cur):
-            cur.execute(
-                f"CREATE TEMP TABLE {_COPY_INSERT_TEMP} ("
-                "subject TEXT, predicate TEXT, object TEXT, "
-                "datatype TEXT, lang TEXT) ON COMMIT DROP"
-            )
-            copy_sql = (
-                f"COPY {_COPY_INSERT_TEMP} "
-                "(subject, predicate, object, datatype, lang) FROM STDIN"
-            )
-            with cur.copy(copy_sql) as cp:
-                for t in batch:
-                    dt, lg = self._literal_meta(t)
-                    cp.write_row(
-                        (
-                            (t.get("subject", "") or ""),
-                            (t.get("predicate", "") or ""),
-                            (t.get("object", "") or ""),
-                            dt,
-                            lg,
+        try:
+            with self._txn_cursor() as (_, cur):
+                cur.execute(
+                    f"CREATE TEMP TABLE {_COPY_INSERT_TEMP} ("
+                    "subject TEXT, predicate TEXT, object TEXT, "
+                    "datatype TEXT, lang TEXT) ON COMMIT DROP"
+                )
+                copy_sql = (
+                    f"COPY {_COPY_INSERT_TEMP} "
+                    "(subject, predicate, object, datatype, lang) FROM STDIN"
+                )
+                with cur.copy(copy_sql) as cp:
+                    for t in batch:
+                        dt, lg = self._literal_meta(t)
+                        cp.write_row(
+                            (
+                                (t.get("subject", "") or ""),
+                                (t.get("predicate", "") or ""),
+                                (t.get("object", "") or ""),
+                                dt,
+                                lg,
+                            )
                         )
-                    )
-            cur.execute(
-                f"INSERT INTO {phy} (subject, predicate, object, datatype, lang) "
-                f"SELECT subject, predicate, object, datatype, lang "
-                f"FROM {_COPY_INSERT_TEMP} ON CONFLICT DO NOTHING"
-            )
+                cur.execute(
+                    f"INSERT INTO {phy} (subject, predicate, object, datatype, lang) "
+                    f"SELECT subject, predicate, object, datatype, lang "
+                    f"FROM {_COPY_INSERT_TEMP} ON CONFLICT DO NOTHING"
+                )
+        except Exception as exc:
+            _reraise_lakebase_index_limit(exc, batch)
         return len(batch)
 
     def _copy_insert_batch(

--- a/src/back/core/graphdb/lakebase/LakebaseFlatStore.py
+++ b/src/back/core/graphdb/lakebase/LakebaseFlatStore.py
@@ -312,6 +312,17 @@ class LakebaseFlatStore(LakebaseBase):
             _time.sleep(min(poll_interval_s, remaining))
 
         with self._cursor() as cur:
+            # managed_synced: Lakeflow creates the _sync table. Re-apply index
+            # DDL idempotently so BFS and neighbour traversals stay performant
+            # even if the physical _sync table was recreated upstream.
+            try:
+                _companion_ddl.ensure_graph_indexes(cur, synced)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "ensure_synced_union_view: could not ensure indexes on %s: %s",
+                    synced,
+                    exc,
+                )
             _companion_ddl.ensure_union_view(cur, view, synced, companion)
 
     @staticmethod

--- a/src/back/core/graphdb/lakebase/_companion_ddl.py
+++ b/src/back/core/graphdb/lakebase/_companion_ddl.py
@@ -23,6 +23,31 @@ from typing import Any
 
 from back.core.helpers import safe_identifier
 
+# Lakeflow synced-table PK (object_hash comes from the Delta warehouse view).
+LAKEFLOW_SYNC_PRIMARY_KEY: tuple[str, ...] = (
+    "subject",
+    "predicate",
+    "object_hash",
+)
+
+_TRIPLE_TABLE_COLUMNS = """
+            subject TEXT NOT NULL,
+            predicate TEXT NOT NULL,
+            object TEXT NOT NULL,
+            object_hash BYTEA GENERATED ALWAYS AS (
+                digest(coalesce(object, ''), 'sha256')
+            ) STORED,
+            datatype TEXT,
+            lang TEXT,
+            PRIMARY KEY (subject, predicate, object_hash)
+"""
+
+_TRIPLE_TABLE_INDEXES: tuple[tuple[str, str], ...] = (
+    ("sp", "subject, predicate"),
+    ("po", "predicate, object_hash"),
+    ("oph", "object_hash, predicate"),
+)
+
 
 def _safe(name: str) -> str:
     return (safe_identifier(name) or "triples").lower()
@@ -52,6 +77,37 @@ def _idx_name(table: str, suffix: str) -> str:
     return base[:63]
 
 
+def ensure_pgcrypto(cur: Any) -> None:
+    """Enable ``digest()`` for generated ``object_hash`` columns."""
+    cur.execute("CREATE EXTENSION IF NOT EXISTS pgcrypto")
+
+
+def wrap_triple_view_sql_for_lakeflow(spark_sql: str) -> str:
+    """Wrap translated Spark SQL so the view exposes ``object_hash`` for Lakeflow."""
+    inner = spark_sql.strip().rstrip(";")
+    return (
+        "SELECT subject, predicate, object, "
+        "sha2(cast(object AS string), 256) AS object_hash "
+        f"FROM ({inner}) AS _ob_triples"
+    )
+
+
+def _create_triple_table(cur: Any, schema: str, table: str) -> None:
+    cur.execute(f'CREATE SCHEMA IF NOT EXISTS "{schema}"')
+    cur.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {table} (
+        {_TRIPLE_TABLE_COLUMNS}
+        )
+        """
+    )
+    for sfx, cols in _TRIPLE_TABLE_INDEXES:
+        cur.execute(
+            f"CREATE INDEX IF NOT EXISTS {_idx_name(table, sfx)} "
+            f"ON {table} ({cols})"
+        )
+
+
 def ensure_synced(cur: Any, schema: str, synced: str) -> None:
     """Create the *_sync bulk-data table + standard B-tree indexes if absent.
 
@@ -59,28 +115,8 @@ def ensure_synced(cur: Any, schema: str, synced: str) -> None:
     warehouse-streamed triples.  In ``managed_synced`` mode this table is
     created by Lakebase/Lakeflow instead.
     """
-    cur.execute(f'CREATE SCHEMA IF NOT EXISTS "{schema}"')
-    cur.execute(
-        f"""
-        CREATE TABLE IF NOT EXISTS {synced} (
-            subject TEXT NOT NULL,
-            predicate TEXT NOT NULL,
-            object TEXT NOT NULL,
-            datatype TEXT,
-            lang TEXT,
-            PRIMARY KEY (subject, predicate, object)
-        )
-        """
-    )
-    for sfx, cols in (
-        ("sp", "subject, predicate"),
-        ("po", "predicate, object"),
-        ("ops", "object, predicate"),
-    ):
-        cur.execute(
-            f"CREATE INDEX IF NOT EXISTS {_idx_name(synced, sfx)} "
-            f"ON {synced} ({cols})"
-        )
+    ensure_pgcrypto(cur)
+    _create_triple_table(cur, schema, synced)
 
 
 def drop_synced(cur: Any, synced: str) -> None:
@@ -112,28 +148,8 @@ def drop_synced(cur: Any, synced: str) -> None:
 
 def ensure_companion(cur: Any, schema: str, companion: str) -> None:
     """Create the writable companion table + standard B-tree indexes if absent."""
-    cur.execute(f'CREATE SCHEMA IF NOT EXISTS "{schema}"')
-    cur.execute(
-        f"""
-        CREATE TABLE IF NOT EXISTS {companion} (
-            subject TEXT NOT NULL,
-            predicate TEXT NOT NULL,
-            object TEXT NOT NULL,
-            datatype TEXT,
-            lang TEXT,
-            PRIMARY KEY (subject, predicate, object)
-        )
-        """
-    )
-    for sfx, cols in (
-        ("sp", "subject, predicate"),
-        ("po", "predicate, object"),
-        ("ops", "object, predicate"),
-    ):
-        cur.execute(
-            f"CREATE INDEX IF NOT EXISTS {_idx_name(companion, sfx)} "
-            f"ON {companion} ({cols})"
-        )
+    ensure_pgcrypto(cur)
+    _create_triple_table(cur, schema, companion)
 
 
 def ensure_union_view(

--- a/src/back/core/graphdb/lakebase/_companion_ddl.py
+++ b/src/back/core/graphdb/lakebase/_companion_ddl.py
@@ -92,6 +92,89 @@ def wrap_triple_view_sql_for_lakeflow(spark_sql: str) -> str:
     )
 
 
+def _table_bare_name(table_ref: str) -> str:
+    return table_ref.split(".")[-1].strip('"')
+
+
+def _table_exists(cur: Any, bare_name: str) -> bool:
+    cur.execute(
+        """
+        SELECT 1
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE c.relname = %s
+          AND n.nspname = ANY(current_schemas(false))
+          AND c.relkind = 'r'
+        LIMIT 1
+        """,
+        (bare_name,),
+    )
+    return cur.fetchone() is not None
+
+
+def _has_object_hash_column(cur: Any, bare_name: str) -> bool:
+    cur.execute(
+        """
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = ANY(current_schemas(false))
+          AND table_name = %s
+          AND column_name = 'object_hash'
+        LIMIT 1
+        """,
+        (bare_name,),
+    )
+    return cur.fetchone() is not None
+
+
+def upgrade_legacy_triple_table_to_object_hash(cur: Any, table_ref: str) -> None:
+    """Migrate pre-0.6.2 triple tables that still key on full ``object`` text.
+
+    ``CREATE TABLE IF NOT EXISTS`` leaves legacy companions in place; without
+    this step ``ensure_graph_indexes`` fails with ``column "object_hash" does
+    not exist`` when (re)building managed_synced graphs.
+    """
+    bare = _table_bare_name(table_ref)
+    if not _table_exists(cur, bare) or _has_object_hash_column(cur, bare):
+        return
+
+    ensure_pgcrypto(cur)
+
+    for sfx, _ in _TRIPLE_TABLE_INDEXES:
+        cur.execute(f"DROP INDEX IF EXISTS {_idx_name(bare, sfx)}")
+
+    cur.execute(
+        f"ALTER TABLE {table_ref} "
+        "ADD COLUMN IF NOT EXISTS object_hash BYTEA GENERATED ALWAYS AS "
+        "(digest(coalesce(object, ''), 'sha256')) STORED"
+    )
+    cur.execute(f"ALTER TABLE {table_ref} ADD COLUMN IF NOT EXISTS datatype TEXT")
+    cur.execute(f"ALTER TABLE {table_ref} ADD COLUMN IF NOT EXISTS lang TEXT")
+
+    cur.execute(
+        f"""
+        DO $$ DECLARE pk_name text;
+        BEGIN
+          SELECT c.conname INTO pk_name
+          FROM pg_constraint c
+          JOIN pg_class t ON t.oid = c.conrelid
+          JOIN pg_namespace n ON n.oid = t.relnamespace
+          WHERE c.contype = 'p'
+            AND t.relname = {bare!r}
+            AND n.nspname = ANY(current_schemas(false))
+          LIMIT 1;
+          IF pk_name IS NOT NULL THEN
+            EXECUTE format('ALTER TABLE %I DROP CONSTRAINT %I', {bare!r}, pk_name);
+          END IF;
+        END $$;
+        """
+    )
+    cur.execute(
+        f"ALTER TABLE {table_ref} "
+        "ADD PRIMARY KEY (subject, predicate, object_hash)"
+    )
+
+
 def ensure_graph_indexes(cur: Any, table_ref: str) -> None:
     """Create standard graph lookup indexes on *table_ref* if absent.
 
@@ -115,6 +198,7 @@ def _create_triple_table(cur: Any, schema: str, table: str) -> None:
         )
         """
     )
+    upgrade_legacy_triple_table_to_object_hash(cur, table)
     ensure_graph_indexes(cur, table)
 
 

--- a/src/back/core/graphdb/lakebase/_companion_ddl.py
+++ b/src/back/core/graphdb/lakebase/_companion_ddl.py
@@ -92,6 +92,20 @@ def wrap_triple_view_sql_for_lakeflow(spark_sql: str) -> str:
     )
 
 
+def ensure_graph_indexes(cur: Any, table_ref: str) -> None:
+    """Create standard graph lookup indexes on *table_ref* if absent.
+
+    ``table_ref`` may be bare (``g_x_v1_sync``) or schema-qualified
+    (``"schema".g_x_v1_sync``). Index names use the physical table name only.
+    """
+    table_name = table_ref.split(".")[-1].strip('"')
+    for sfx, cols in _TRIPLE_TABLE_INDEXES:
+        cur.execute(
+            f"CREATE INDEX IF NOT EXISTS {_idx_name(table_name, sfx)} "
+            f"ON {table_ref} ({cols})"
+        )
+
+
 def _create_triple_table(cur: Any, schema: str, table: str) -> None:
     cur.execute(f'CREATE SCHEMA IF NOT EXISTS "{schema}"')
     cur.execute(
@@ -101,11 +115,7 @@ def _create_triple_table(cur: Any, schema: str, table: str) -> None:
         )
         """
     )
-    for sfx, cols in _TRIPLE_TABLE_INDEXES:
-        cur.execute(
-            f"CREATE INDEX IF NOT EXISTS {_idx_name(table, sfx)} "
-            f"ON {table} ({cols})"
-        )
+    ensure_graph_indexes(cur, table)
 
 
 def ensure_synced(cur: Any, schema: str, synced: str) -> None:

--- a/src/back/core/graphdb/lakebase/schema.sql
+++ b/src/back/core/graphdb/lakebase/schema.sql
@@ -1,5 +1,8 @@
 -- Reference DDL for one OntoBricks flat triple table on Lakebase Postgres.
 -- Replace <schema> and <table> with validated identifiers (see LakebaseFlatStore).
+-- Requires the pgcrypto extension for digest().
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
 CREATE SCHEMA IF NOT EXISTS "<schema>";
 
@@ -7,11 +10,12 @@ CREATE TABLE IF NOT EXISTS "<schema>"."<table>" (
     subject     TEXT NOT NULL,
     predicate   TEXT NOT NULL,
     object      TEXT NOT NULL,
+    object_hash BYTEA GENERATED ALWAYS AS (digest(coalesce(object, ''), 'sha256')) STORED,
     datatype    TEXT,
     lang        TEXT,
-    PRIMARY KEY (subject, predicate, object)
+    PRIMARY KEY (subject, predicate, object_hash)
 );
 
 CREATE INDEX IF NOT EXISTS ix_<table>_sp  ON "<schema>"."<table>" (subject, predicate);
-CREATE INDEX IF NOT EXISTS ix_<table>_po  ON "<schema>"."<table>" (predicate, object);
-CREATE INDEX IF NOT EXISTS ix_<table>_ops ON "<schema>"."<table>" (object, predicate);
+CREATE INDEX IF NOT EXISTS ix_<table>_po  ON "<schema>"."<table>" (predicate, object_hash);
+CREATE INDEX IF NOT EXISTS ix_<table>_oph ON "<schema>"."<table>" (object_hash, predicate);

--- a/src/back/objects/digitaltwin/_build_pipeline.py
+++ b/src/back/objects/digitaltwin/_build_pipeline.py
@@ -508,8 +508,15 @@ class _BuildPipeline:
         )
         try:
             catalog, schema, vname = self.parts
+            view_sql = self.spark_sql
+            if self._lakebase_managed_synced():
+                from back.core.graphdb.lakebase._companion_ddl import (
+                    wrap_triple_view_sql_for_lakeflow,
+                )
+
+                view_sql = wrap_triple_view_sql_for_lakeflow(view_sql)
             view_ok, view_msg = self.source_client.create_or_replace_view(
-                catalog, schema, vname, self.spark_sql
+                catalog, schema, vname, view_sql
             )
             if not view_ok:
                 if self.is_api:
@@ -888,10 +895,14 @@ class _BuildPipeline:
                 self.view_table,
                 self.store.sync_table_mode,
             )
+            from back.core.graphdb.lakebase._companion_ddl import (
+                LAKEFLOW_SYNC_PRIMARY_KEY,
+            )
+
             _synced_obj = mgr.ensure(
                 synced_uc,
                 source_table_full_name=self.view_table,
-                primary_key_columns=["subject", "predicate", "object"],
+                primary_key_columns=list(LAKEFLOW_SYNC_PRIMARY_KEY),
                 sync_mode=self.store.sync_table_mode,
             )
             # ensure() may have used a fallback name (ghost control-plane state);
@@ -1382,8 +1393,24 @@ class _BuildPipeline:
             duration,
             exc,
         )
-        if self.is_api:
-            self.tm.fail_task(self.task_id, str(exc))
-        else:
-            self.tm.fail_task(self.task_id, "Triple store sync failed")
+        self.tm.fail_task(self.task_id, self._sync_failure_message(exc))
         self._record_build_run("error", error=str(exc))
+
+    def _sync_failure_message(self, exc: Exception) -> str:
+        from back.core.errors import InfrastructureError
+        from back.core.graphdb.lakebase.LakebaseFlatStore import (
+            _is_index_row_size_error,
+        )
+
+        if isinstance(exc, InfrastructureError):
+            return str(exc)
+        if _is_index_row_size_error(exc):
+            return (
+                "Triple store sync failed: a mapped literal object exceeds the "
+                "Postgres btree index size limit. Run a full Knowledge Graph rebuild "
+                "to apply the object_hash schema fix, or exclude very long text "
+                "columns from mapping."
+            )
+        if self.is_api:
+            return str(exc)
+        return f"Triple store sync failed: {exc}"

--- a/src/back/objects/digitaltwin/_build_pipeline.py
+++ b/src/back/objects/digitaltwin/_build_pipeline.py
@@ -299,6 +299,35 @@ class _BuildPipeline:
         """Return ``True`` when bulk data movement should be delegated to Lakeflow."""
         return self._is_lakebase_synced
 
+    def _sync_flags_from_store(self) -> None:
+        """Align build flags with the opened graph store (authoritative sync mode)."""
+        if self._store_is_synced():
+            if not self._is_lakebase_synced:
+                logger.warning(
+                    "[DT-BUILD %s] graph store reports managed_synced but mode "
+                    "resolution did not — using store sync_mode for VIEW/Lakeflow",
+                    self.task_id,
+                )
+            self._is_lakebase_synced = True
+
+    def _store_is_synced(self) -> bool:
+        """Return ``True`` only when the opened store is in managed_synced mode."""
+        if self.store is None:
+            return False
+        return getattr(self.store, "is_synced", False) is True
+
+    def _wrap_view_sql_for_lakeflow(self) -> bool:
+        """Return ``True`` when the warehouse VIEW must expose ``object_hash``."""
+        if self._store_is_synced():
+            return True
+        return self._lakebase_managed_synced()
+
+    def _uses_synced_pipeline(self) -> bool:
+        """Return ``True`` when the apply phase should delegate bulk sync to Lakeflow."""
+        if self._store_is_synced():
+            return True
+        return self._lakebase_managed_synced()
+
     def _count_view_triples(self) -> int:
         """Return the number of triples in the VIEW (server-side COUNT)."""
         logger.debug(
@@ -341,6 +370,10 @@ class _BuildPipeline:
 
             self._resolve_lakebase_mode()
 
+            if not self._open_store():
+                return
+            self._sync_flags_from_store()
+
             t_phase = time.time()
             if not self._create_view():
                 return
@@ -349,9 +382,6 @@ class _BuildPipeline:
 
             t_phase = time.time()
             self._announce_apply_step()
-
-            if not self._open_store():
-                return
 
             if not self._apply_full_rebuild():
                 return
@@ -495,6 +525,17 @@ class _BuildPipeline:
         )
         return True
 
+    def _view_sql_for_build(self) -> str:
+        """Return warehouse VIEW DDL, including ``object_hash`` when Lakeflow sync is active."""
+        view_sql = self.spark_sql or ""
+        if self._wrap_view_sql_for_lakeflow():
+            from back.core.graphdb.lakebase._companion_ddl import (
+                wrap_triple_view_sql_for_lakeflow,
+            )
+
+            view_sql = wrap_triple_view_sql_for_lakeflow(view_sql)
+        return view_sql
+
     def _create_view(self) -> bool:
         """Create or replace the Spark VIEW. Returns ``False`` on failure."""
         from back.objects.digitaltwin.DigitalTwin import DigitalTwin
@@ -508,13 +549,7 @@ class _BuildPipeline:
         )
         try:
             catalog, schema, vname = self.parts
-            view_sql = self.spark_sql
-            if self._lakebase_managed_synced():
-                from back.core.graphdb.lakebase._companion_ddl import (
-                    wrap_triple_view_sql_for_lakeflow,
-                )
-
-                view_sql = wrap_triple_view_sql_for_lakeflow(view_sql)
+            view_sql = self._view_sql_for_build()
             view_ok, view_msg = self.source_client.create_or_replace_view(
                 catalog, schema, vname, view_sql
             )
@@ -565,6 +600,56 @@ class _BuildPipeline:
             )
             self.tm.fail_task(self.task_id, f"Failed to create VIEW: {detail}")
             return False
+
+    def _ensure_lakeflow_source_view(self) -> bool:
+        """Refresh the UC source VIEW so Lakeflow PK columns exist before registration."""
+        if not self._uses_synced_pipeline():
+            return True
+        from back.objects.digitaltwin.DigitalTwin import DigitalTwin
+
+        catalog, schema, vname = self.parts
+        view_sql = self._view_sql_for_build()
+        logger.info(
+            "[DT-BUILD %s] refreshing Lakeflow source VIEW %s (object_hash required)",
+            self.task_id,
+            self.view_table,
+        )
+        try:
+            view_ok, view_msg = self.source_client.create_or_replace_view(
+                catalog, schema, vname, view_sql
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception(
+                "[DT-BUILD %s] failed to refresh Lakeflow source VIEW %s: %s",
+                self.task_id,
+                self.view_table,
+                exc,
+            )
+            self.tm.fail_task(
+                self.task_id,
+                f"Could not refresh Lakeflow source VIEW: {exc}",
+            )
+            return False
+        if view_ok:
+            return True
+        detail = (
+            view_msg
+            if self.is_api
+            else DigitalTwin.diagnose_view_error(
+                view_msg, self.entity_mappings, self.relationship_mappings
+            )
+        )
+        logger.error(
+            "[DT-BUILD %s] failed to refresh Lakeflow source VIEW %s: %s",
+            self.task_id,
+            self.view_table,
+            detail,
+        )
+        self.tm.fail_task(
+            self.task_id,
+            f"Could not refresh Lakeflow source VIEW: {detail}",
+        )
+        return False
 
     def _post_create_view_progress(self) -> None:
         if self.is_api:
@@ -620,7 +705,7 @@ class _BuildPipeline:
         :meth:`_apply_via_synced_pipeline` — the Lakeflow snapshot pipeline
         rewrites the synced PG table and the app does not iterate triples.
         """
-        if self._lakebase_managed_synced():
+        if self._uses_synced_pipeline():
             return self._apply_via_synced_pipeline()
 
         t_fetch = time.time()
@@ -887,6 +972,8 @@ class _BuildPipeline:
 
             # Step 3 — register/reuse the Lakebase synced table.
             t_step = time.time()
+            if not self._ensure_lakeflow_source_view():
+                return False
             logger.debug(
                 "[DT-BUILD %s] step 3/7: registering synced table %s "
                 "(source=%s sync_mode=%s)",
@@ -924,12 +1011,31 @@ class _BuildPipeline:
                 self.task_id,
                 time.time() - t_step,
             )
+        except OperationCancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            logger.exception(
+                "[DT-BUILD %s] failed to register synced table %s: %s "
+                "(source_view=%s pg_schema=%s sync_table_mode=%s)",
+                self.task_id,
+                synced_uc,
+                exc,
+                self.view_table,
+                getattr(self.store, "graph_schema", "?"),
+                getattr(self.store, "sync_table_mode", "?"),
+            )
+            self.tm.fail_task(
+                self.task_id,
+                f"Could not register Lakebase synced table: {exc}",
+            )
+            return False
 
-            _raise_if_cancelled(self._is_cancelled)
-            _adv()  # → "Creating companion table"
+        _raise_if_cancelled(self._is_cancelled)
+        _adv()  # → "Creating companion table"
 
-            # Step 4 — create companion table in Postgres.
-            t_step = time.time()
+        # Step 4 — create companion table in Postgres.
+        t_step = time.time()
+        try:
             logger.debug(
                 "[DT-BUILD %s] step 4/7: creating companion table for %s "
                 "(pg schema=%s)",
@@ -947,18 +1053,16 @@ class _BuildPipeline:
             raise
         except Exception as exc:  # noqa: BLE001
             logger.exception(
-                "[DT-BUILD %s] failed to register synced table %s: %s "
-                "(source_view=%s pg_schema=%s sync_table_mode=%s)",
+                "[DT-BUILD %s] failed to upgrade companion table for %s: %s "
+                "(pg_schema=%s)",
                 self.task_id,
-                synced_uc,
+                self.graph_name,
                 exc,
-                self.view_table,
                 getattr(self.store, "graph_schema", "?"),
-                getattr(self.store, "sync_table_mode", "?"),
             )
             self.tm.fail_task(
                 self.task_id,
-                f"Could not register Lakebase synced table: {exc}",
+                f"Could not prepare Lakebase companion table: {exc}",
             )
             return False
 

--- a/src/back/objects/registry/scheduler.py
+++ b/src/back/objects/registry/scheduler.py
@@ -1027,6 +1027,17 @@ def _is_managed_synced(store) -> bool:
     return bool(getattr(store, "is_synced", False))
 
 
+def _view_sql_for_graph_store(sql_text: str, store) -> str:
+    """Return VIEW DDL, emitting ``object_hash`` when Lakeflow sync is active."""
+    if store and _is_managed_synced(store):
+        from back.core.graphdb.lakebase._companion_ddl import (
+            wrap_triple_view_sql_for_lakeflow,
+        )
+
+        return wrap_triple_view_sql_for_lakeflow(sql_text)
+    return sql_text
+
+
 def _apply_synced_pipeline(
     store,
     src,
@@ -1328,13 +1339,22 @@ def _run_scheduled_build(
             shacl_shapes=getattr(domain, "shacl_shapes", None),
         )
 
+        # Resolve graph backend before VIEW creation so managed_synced builds
+        # can emit object_hash (Lakeflow keys the synced PK on that column).
+        from back.core.triplestore import get_triplestore
+        from back.objects.digitaltwin.models import DomainSnapshot
+
+        snap = DomainSnapshot(domain, host=host, token=token)
+        store = get_triplestore(snap, settings, backend="graph")
+
         # --- Step 2: Create VIEW ---
         tm.advance_step(task.id, f"Creating VIEW {view_table}...")
         src = DatabricksClient(host=host, token=token, warehouse_id=warehouse_id)
 
+        view_sql = _view_sql_for_graph_store(sql_text, store)
         cat, sch, vname = view_table.split(".")
         logger.info("Scheduled build [%s]: creating VIEW %s", domain_name, view_table)
-        view_ok, view_msg = src.create_or_replace_view(cat, sch, vname, sql_text)
+        view_ok, view_msg = src.create_or_replace_view(cat, sch, vname, view_sql)
         if not view_ok:
             from back.objects.digitaltwin import DigitalTwin
 
@@ -1350,11 +1370,6 @@ def _run_scheduled_build(
         # --- Step 3: Populate graph ---
         tm.advance_step(task.id, f"Applying to graph {graph_name}...")
 
-        from back.core.triplestore import get_triplestore
-        from back.objects.digitaltwin.models import DomainSnapshot
-
-        snap = DomainSnapshot(domain, host=host, token=token)
-        store = get_triplestore(snap, settings, backend="graph")
         if not store:
             raise InfrastructureError("Could not initialize graph backend")
 

--- a/src/back/objects/registry/scheduler.py
+++ b/src/back/objects/registry/scheduler.py
@@ -1073,10 +1073,12 @@ def _apply_synced_pipeline(
         synced_uc,
         task_log_prefix=f"Scheduled build [{domain_name}]",
     )
+    from back.core.graphdb.lakebase._companion_ddl import LAKEFLOW_SYNC_PRIMARY_KEY
+
     mgr.ensure(
         synced_uc,
         source_table_full_name=view_table,
-        primary_key_columns=["subject", "predicate", "object"],
+        primary_key_columns=list(LAKEFLOW_SYNC_PRIMARY_KEY),
         sync_mode=store.sync_table_mode,
     )
     store.ensure_synced_companion(graph_name)

--- a/src/front/static/global/css/main.css
+++ b/src/front/static/global/css/main.css
@@ -491,6 +491,29 @@ body {
     align-self: stretch;
 }
 
+/* Resume Editing button — L2 subnav, left of Save, when the edit lease expired */
+.ob-subnav-resume-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    margin-right: 0.4rem;
+    padding: 0.25rem 0.7rem;
+    font-size: 0.8rem;
+    color: #664d03;
+    background-color: #fff3cd;
+    border: 1px solid #ffe69c;
+    border-radius: 0.3rem;
+    white-space: nowrap;
+    cursor: pointer;
+    transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.ob-subnav-resume-btn:hover {
+    background-color: #ffc107;
+    color: #664d03;
+    border-color: #ffda6a;
+}
+
 /* Save Domain button — right-aligned in the L2 subnav */
 .ob-subnav-save-btn {
     display: inline-flex;

--- a/src/front/static/global/js/edit-lock.js
+++ b/src/front/static/global/js/edit-lock.js
@@ -29,11 +29,13 @@
 //      editing" button that renews on the spot. If they ignore the warning
 //      the lease lapses: the lock is *released* server-side (so another user
 //      can take it immediately) and this browser flips to read-only with a
-//      "session expired" banner. A per-version sticky flag (sessionStorage)
-//      then keeps it read-only across incidental reloads / navigation — the
-//      still-free lock is not silently re-grabbed — until the user clicks
-//      "Resume editing". A lease lost to a take-over / stale reclaim flips to
-//      read-only the same way (without the sticky, since it is already gone).
+//      yellow **Resume editing** button in the L2 subnav (left of Save; the
+//      expiry message is a hover tooltip). A per-version sticky flag
+//      (sessionStorage) then keeps it read-only across incidental reloads /
+//      navigation — the still-free lock is not silently re-grabbed — until the
+//      user clicks **Resume editing**. A lease lost to a take-over / stale
+//      reclaim flips to read-only the same way (without the sticky, since it
+//      is already gone).
 //      Hovering the navbar domain badge (#currentDomainName) shows the
 //      remaining-lease countdown while editing.
 //
@@ -70,7 +72,7 @@
     // free lock to the loader) and hand editing straight back — undoing the
     // timeout. The sticky flag (per version, in sessionStorage so it survives
     // reloads but not a new tab) keeps the browser read-only until the user
-    // *explicitly* resumes (the banner's "Resume editing" button).
+    // *explicitly* resumes (the subnav "Resume editing" button).
 
     var STICKY_KEY = 'ob:editLockExpired';
     // "folder\u0000version" of the loaded lockable version, once known.
@@ -174,40 +176,44 @@
         document.body.insertBefore(banner, document.body.firstChild);
     }
 
-    function renderExpiredBanner() {
-        var existing = document.getElementById('editLockBanner');
-        if (existing) existing.remove();
-        var banner = document.createElement('div');
-        banner.id = 'editLockBanner';
+    var resumeTip = null;
 
-        var msg = document.createElement('span');
-        msg.className = 'edit-lock-msg';
-        msg.innerHTML =
-            '<i class="bi bi-hourglass-bottom me-1"></i>' +
-            'Your editing session expired after a period of inactivity — you ' +
-            'now have <strong>read-only</strong> access and saving is disabled. ' +
-            'Click <strong>Resume editing</strong> to reconnect (you regain ' +
-            'editing if no one else has taken over).';
-        banner.appendChild(msg);
+    function expiredTooltipText() {
+        return 'Your editing session expired after a period of inactivity — you ' +
+            'now have read-only access and saving is disabled. Click Resume ' +
+            'editing to reconnect (you regain editing if no one else has taken over).';
+    }
 
-        var actions = document.createElement('span');
-        actions.className = 'edit-lock-actions';
+    function onResumeEditingClick() {
+        // Explicit reconnect: drop the sticky "expired" flag so the reload
+        // is allowed to re-acquire the (still-free) lock.
+        stickyClear();
+        window.location.reload();
+    }
 
-        var reload = document.createElement('button');
-        reload.type = 'button';
-        reload.className = 'btn btn-sm btn-warning';
-        reload.innerHTML =
-            '<i class="bi bi-arrow-clockwise me-1"></i>Resume editing';
-        reload.addEventListener('click', function () {
-            // Explicit reconnect: drop the sticky "expired" flag so the reload
-            // is allowed to re-acquire the (still-free) lock.
-            stickyClear();
-            window.location.reload();
-        });
-        actions.appendChild(reload);
+    function renderResumeEditingButton() {
+        if (document.getElementById('editLockResumeBtn')) return;
 
-        banner.appendChild(actions);
-        document.body.insertBefore(banner, document.body.firstChild);
+        var saveBtn = document.querySelector('.ob-subnav-save-btn');
+        if (!saveBtn || !saveBtn.parentNode) return;
+
+        var btn = document.createElement('button');
+        btn.type = 'button';
+        btn.id = 'editLockResumeBtn';
+        btn.className = 'ob-subnav-resume-btn';
+        btn.innerHTML =
+            '<i class="bi bi-arrow-clockwise"></i> Resume editing';
+        btn.setAttribute('aria-label', expiredTooltipText());
+        btn.addEventListener('click', onResumeEditingClick);
+        saveBtn.parentNode.insertBefore(btn, saveBtn);
+
+        if (window.bootstrap && window.bootstrap.Tooltip) {
+            resumeTip = new window.bootstrap.Tooltip(btn, {
+                title: expiredTooltipText(),
+                trigger: 'hover focus',
+                placement: 'bottom',
+            });
+        }
     }
 
     // ----- lease keep-alive (renew) ---------------------------------
@@ -268,7 +274,7 @@
         teardownLeaseTooltip();
         window.editLockMode = 'view';
         enterReadOnly({});
-        renderExpiredBanner();
+        renderResumeEditingButton();
     }
 
     // Lease lapsed through inactivity: give the lock up server-side (so another
@@ -562,7 +568,7 @@
                 window.editLockMode = 'view';
                 releaseLock();
                 enterReadOnly({});
-                renderExpiredBanner();
+                renderResumeEditingButton();
             } else {
                 // This browser holds the lock — keep its lease alive.
                 window.editLockMode = 'edit';

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,17 @@ def setup_test_env(monkeypatch):
     monkeypatch.setenv("DATABRICKS_DISABLE_CLOUD_FETCH", "1")
     monkeypatch.delenv("DATABRICKS_FORCE_CLOUD_FETCH", raising=False)
     monkeypatch.setenv("CSRF_DISABLED", "1")
+    # Prevent a developer's .env Lakebase coordinates from leaking into unit
+    # tests — otherwise RegistryCfg / graph-engine probes hit a real (or
+    # mis-matched) workspace and block the suite.
+    for _lakebase_var in (
+        "LAKEBASE_PROJECT",
+        "LAKEBASE_BRANCH",
+        "LAKEBASE_DATABASE",
+        "PGHOST",
+        "PGDATABASE",
+    ):
+        monkeypatch.delenv(_lakebase_var, raising=False)
 
 
 @pytest.fixture

--- a/tests/units/auth/test_permission_middleware.py
+++ b/tests/units/auth/test_permission_middleware.py
@@ -1308,3 +1308,15 @@ class TestLifecycleGateInDispatch:
             path="/ontology/entities",
         )
         assert result.get("passed")
+
+    @pytest.mark.parametrize("status", ["PUBLISHED", "IN-REVIEW"])
+    def test_kg_filter_allowed_on_non_draft(self, status):
+        """KG filtering is read-only; it must stay available on locked versions."""
+        _, _, result = _dispatch_with_status(
+            ROLE_APP_USER, ROLE_BUILDER,
+            version_status=status,
+            path="/dtwin/sync/filter",
+        )
+        assert result.get("passed"), (
+            f"KG filter should be allowed on {status} version"
+        )

--- a/tests/units/core/test_lakebase_flat_store.py
+++ b/tests/units/core/test_lakebase_flat_store.py
@@ -730,6 +730,37 @@ def test_wrap_triple_view_sql_for_lakeflow_adds_object_hash():
     assert wrapped.endswith("FROM (SELECT 's' AS subject, 'p' AS predicate, 'o' AS object) AS _ob_triples")
 
 
+def test_upgrade_legacy_triple_table_adds_object_hash_and_pk():
+    from back.core.graphdb.lakebase._companion_ddl import (
+        upgrade_legacy_triple_table_to_object_hash,
+    )
+
+    cur = MagicMock()
+    cur.fetchone.side_effect = [(1,), None]
+
+    upgrade_legacy_triple_table_to_object_hash(cur, "cust360auto_v5__app")
+
+    executed = " ".join(str(c[0][0]) for c in cur.execute.call_args_list)
+    assert "ADD COLUMN IF NOT EXISTS object_hash" in executed
+    assert "DROP CONSTRAINT" in executed
+    assert "ADD PRIMARY KEY (subject, predicate, object_hash)" in executed
+    assert "DROP INDEX IF EXISTS" in executed
+
+
+def test_create_triple_table_migrates_legacy_before_indexes():
+    from back.core.graphdb.lakebase._companion_ddl import _create_triple_table
+
+    cur = MagicMock()
+    cur.fetchone.side_effect = [(1,), None]
+
+    _create_triple_table(cur, "ontobricks_graph", "g_v1__app")
+
+    executed = [str(c[0][0]) for c in cur.execute.call_args_list]
+    assert any("CREATE TABLE IF NOT EXISTS g_v1__app" in s for s in executed)
+    assert any("ADD COLUMN IF NOT EXISTS object_hash" in s for s in executed)
+    assert any("CREATE INDEX IF NOT EXISTS" in s and "object_hash" in s for s in executed)
+
+
 def test_scheduled_view_sql_wraps_object_hash_for_managed_synced():
     from back.objects.registry.scheduler import _view_sql_for_graph_store
 

--- a/tests/units/core/test_lakebase_flat_store.py
+++ b/tests/units/core/test_lakebase_flat_store.py
@@ -520,6 +520,22 @@ class TestManagedSyncedRouting:
         assert "FROM g_v1_sync" in view_ddl
         assert '"ontobricks_graph"' not in view_ddl
 
+    def test_ensure_synced_union_view_ensures_graph_indexes_on_sync_table(self, synced_store):
+        """managed_synced builds re-apply graph indexes on Lakeflow-owned _sync tables."""
+        cur = MagicMock()
+        with patch.object(synced_store, "_cursor", _cursor_ctx(cur)):
+            synced_store.ensure_synced_union_view("G_V1")
+        executed = [str(c[0][0]) for c in cur.execute.call_args_list]
+        index_ddls = [s for s in executed if "CREATE INDEX IF NOT EXISTS" in s]
+        assert len(index_ddls) == 3
+        assert all("ON g_v1_sync" in s for s in index_ddls)
+        assert any("subject, predicate" in s for s in index_ddls)
+        assert any("predicate, object_hash" in s for s in index_ddls)
+        assert any("object_hash, predicate" in s for s in index_ddls)
+        view_idx = next(i for i, s in enumerate(executed) if "CREATE OR REPLACE VIEW" in s)
+        first_index_idx = next(i for i, s in enumerate(executed) if "CREATE INDEX IF NOT EXISTS" in s)
+        assert first_index_idx < view_idx
+
     def test_ensure_synced_companion_skips_union_view(self, synced_store):
         cur = MagicMock()
         with patch.object(synced_store, "_cursor", _cursor_ctx(cur)):

--- a/tests/units/core/test_lakebase_flat_store.py
+++ b/tests/units/core/test_lakebase_flat_store.py
@@ -713,3 +713,19 @@ def test_wrap_triple_view_sql_for_lakeflow_adds_object_hash():
     assert "sha2(cast(object AS string), 256) AS object_hash" in wrapped
     assert wrapped.endswith("FROM (SELECT 's' AS subject, 'p' AS predicate, 'o' AS object) AS _ob_triples")
 
+
+def test_scheduled_view_sql_wraps_object_hash_for_managed_synced():
+    from back.objects.registry.scheduler import _view_sql_for_graph_store
+
+    inner = "SELECT subject, predicate, object FROM t"
+    managed = MagicMock()
+    managed.is_synced = True
+    wrapped = _view_sql_for_graph_store(inner, managed)
+    assert "object_hash" in wrapped
+    assert inner in wrapped
+
+    app_managed = MagicMock()
+    app_managed.is_synced = False
+    assert _view_sql_for_graph_store(inner, app_managed) == inner
+    assert _view_sql_for_graph_store(inner, None) == inner
+

--- a/tests/units/core/test_lakebase_flat_store.py
+++ b/tests/units/core/test_lakebase_flat_store.py
@@ -745,3 +745,56 @@ def test_scheduled_view_sql_wraps_object_hash_for_managed_synced():
     assert _view_sql_for_graph_store(inner, app_managed) == inner
     assert _view_sql_for_graph_store(inner, None) == inner
 
+
+def test_find_subjects_by_patterns_empty(auth):
+    store = LakebaseFlatStore(auth, schema="ontobricks_graph")
+    with patch.object(store, "execute_query") as mock_eq:
+        result = store.find_subjects_by_patterns("MyGraph_V1", [])
+    assert result == set()
+    mock_eq.assert_not_called()
+
+
+def test_find_subjects_by_patterns_suffix_fast_path(auth):
+    store = LakebaseFlatStore(auth, schema="ontobricks_graph")
+    with patch.object(store, "execute_query", return_value=[{"subject": "http://ex/WTG:1"}]) as mock_eq:
+        result = store.find_subjects_by_patterns(
+            "MyGraph_V1",
+            ["%/WTG:1", "%/WTG:2", "%/CUST:10"],
+        )
+    assert result == {"http://ex/WTG:1"}
+    mock_eq.assert_called_once()
+    sql = mock_eq.call_args[0][0]
+    assert "RIGHT(subject," in sql
+    assert "ANY(ARRAY" in sql
+    assert "LIKE" not in sql
+    assert "'/WTG:1'" in sql
+    assert "'/WTG:2'" in sql
+    assert "'/CUST:10'" in sql
+
+
+def test_find_subjects_by_patterns_generic_fallback(auth):
+    store = LakebaseFlatStore(auth, schema="ontobricks_graph")
+    with patch.object(
+        store,
+        "execute_query",
+        side_effect=[
+            [{"subject": "http://ex/a"}],
+            [{"subject": "http://ex/b"}],
+        ],
+    ) as mock_eq:
+        result = store.find_subjects_by_patterns(
+            "MyGraph_V1",
+            ["%/WTG:1", "%/foo%bar"],
+        )
+    assert result == {"http://ex/a", "http://ex/b"}
+    assert mock_eq.call_count == 2
+    assert "RIGHT(subject," in mock_eq.call_args_list[0][0][0]
+    assert "LIKE" in mock_eq.call_args_list[1][0][0]
+
+
+def test_find_subjects_by_patterns_escapes_quotes(auth):
+    store = LakebaseFlatStore(auth, schema="ontobricks_graph")
+    with patch.object(store, "execute_query", return_value=[]) as mock_eq:
+        store.find_subjects_by_patterns("MyGraph_V1", ["%/O'Brien"])
+    sql = mock_eq.call_args[0][0]
+    assert "O''Brien" in sql

--- a/tests/units/core/test_lakebase_flat_store.py
+++ b/tests/units/core/test_lakebase_flat_store.py
@@ -7,6 +7,7 @@ import pytest
 
 pytest.importorskip("psycopg")
 
+from back.core.errors import InfrastructureError
 from back.core.graphdb.lakebase.LakebaseFlatStore import LakebaseFlatStore
 
 
@@ -77,6 +78,9 @@ def test_create_table_issues_schema_ddl_and_indexes(auth):
     # Union view must be created.
     assert any("CREATE OR REPLACE VIEW" in s and "mydomain_v1" in s for s in executed)
     assert any("CREATE INDEX" in s for s in executed)
+    assert any("CREATE EXTENSION IF NOT EXISTS pgcrypto" in s for s in executed)
+    assert any("object_hash" in s and "digest" in s for s in create_tables)
+    assert any("PRIMARY KEY (subject, predicate, object_hash)" in s for s in create_tables)
 
 
 def test_writable_table_id_is_companion_for_app_managed(auth):
@@ -675,4 +679,37 @@ class TestResolveSyncUcFallbackCatalog:
                 {"catalog": "benoit_cayla"},
             )
         assert out == "legacy_catalog"
+
+
+def test_copy_insert_batch_phy_reraises_index_limit_with_predicate_detail(auth):
+    store = LakebaseFlatStore(auth, schema="ontobricks_graph")
+    long_object = "x" * 4000
+    batch = [
+        {
+            "subject": "http://ex/s",
+            "predicate": "http://ex/longMessage",
+            "object": long_object,
+        }
+    ]
+
+    class _ProgramLimitExceeded(Exception):
+        pass
+
+    def _boom(*_args, **_kwargs):
+        raise _ProgramLimitExceeded(
+            'index row size 7480 exceeds btree version 4 maximum 2704 for index "g_v1_sync_pkey"'
+        )
+
+    with patch.object(store, "_txn_cursor", side_effect=_boom):
+        with pytest.raises(InfrastructureError, match="predicate='http://ex/longMessage'"):
+            store._copy_insert_batch_phy("g_v1_sync", batch)
+
+
+def test_wrap_triple_view_sql_for_lakeflow_adds_object_hash():
+    from back.core.graphdb.lakebase._companion_ddl import wrap_triple_view_sql_for_lakeflow
+
+    inner = "SELECT 's' AS subject, 'p' AS predicate, 'o' AS object"
+    wrapped = wrap_triple_view_sql_for_lakeflow(inner)
+    assert "sha2(cast(object AS string), 256) AS object_hash" in wrapped
+    assert wrapped.endswith("FROM (SELECT 's' AS subject, 'p' AS predicate, 'o' AS object) AS _ob_triples")
 

--- a/tests/units/core/test_synced_table_manager.py
+++ b/tests/units/core/test_synced_table_manager.py
@@ -109,7 +109,7 @@ class TestEnsure:
         out = mgr.ensure(
             "cat.sch.tab",
             source_table_full_name="cat.sch.view",
-            primary_key_columns=["subject", "predicate", "object"],
+            primary_key_columns=["subject", "predicate", "object_hash"],
         )
         assert out is not None
         client.database.create_synced_database_table.assert_not_called()
@@ -134,7 +134,7 @@ class TestEnsure:
             mgr.ensure(
                 "cat.sch.tab",
                 source_table_full_name="cat.sch.view",
-                primary_key_columns=["subject", "predicate", "object"],
+                primary_key_columns=["subject", "predicate", "object_hash"],
                 sync_mode="snapshot",
             )
         client.database.create_synced_database_table.assert_called_once()
@@ -143,7 +143,7 @@ class TestEnsure:
         assert captured["payload"]["primary_key_columns"] == [
             "subject",
             "predicate",
-            "object",
+            "object_hash",
         ]
         assert captured["payload"]["sync_mode"] == "snapshot"
         # project/branch are instance attrs consumed by the builder internals.
@@ -171,7 +171,7 @@ class TestEnsure:
             out = mgr.ensure(
                 "cat.sch.tab",
                 source_table_full_name="cat.sch.view",
-                primary_key_columns=["subject", "predicate", "object"],
+                primary_key_columns=["subject", "predicate", "object_hash"],
             )
         assert out is not None  # ownership-probe returned the winner
 

--- a/tests/units/dtwin/test_build_pipeline_streaming.py
+++ b/tests/units/dtwin/test_build_pipeline_streaming.py
@@ -25,6 +25,7 @@ def _bare_pipeline(**overrides):
     pipe.task_id = "t-test"
     pipe.graph_name = "G_V1"
     pipe.view_table = "cat.sch.v_g"
+    pipe.parts = pipe.view_table.split(".")
     pipe.source_client = MagicMock()
     pipe.store = MagicMock()
     pipe.tm = MagicMock()
@@ -165,6 +166,8 @@ class TestApplyViaSyncedPipeline:
         pipe.store.ensure_synced_union_view = MagicMock()
         pipe.store.truncate_companion = MagicMock()
         pipe._count_view_triples = MagicMock(return_value=1234)
+        pipe.spark_sql = "SELECT 's' AS subject, 'p' AS predicate, 'o' AS object"
+        pipe.source_client.create_or_replace_view.return_value = (True, "ok")
         pipe._mgr = mgr
         # _raise_if_cancelled calls tm.is_cancelled(); return False so cancel
         # checks don't abort the pipeline in unit tests.
@@ -247,6 +250,35 @@ class TestResolveLakebaseMode:
             pipe._resolve_lakebase_mode()
 
         assert pipe._is_lakebase_synced is False
+
+
+class TestLakeflowViewWrap:
+    """VIEW DDL must expose object_hash whenever the graph store is managed_synced."""
+
+    def test_wrap_follows_opened_store_when_mode_resolution_missed(self):
+        pipe = _bare_pipeline(_is_lakebase_synced=False)
+        pipe.spark_sql = "SELECT 's' AS subject, 'p' AS predicate, 'o' AS object"
+        pipe.store.is_synced = True
+
+        pipe._sync_flags_from_store()
+
+        assert pipe._is_lakebase_synced is True
+        assert pipe._wrap_view_sql_for_lakeflow() is True
+        wrapped = pipe._view_sql_for_build()
+        assert "object_hash" in wrapped
+
+    def test_ensure_lakeflow_source_view_refreshes_view(self):
+        pipe = _bare_pipeline(_is_lakebase_synced=True)
+        pipe.spark_sql = "SELECT 's' AS subject, 'p' AS predicate, 'o' AS object"
+        pipe.parts = ("cat", "sch", "v_g")
+        pipe.store.is_synced = True
+        pipe.source_client.create_or_replace_view.return_value = (True, "ok")
+
+        assert pipe._ensure_lakeflow_source_view() is True
+
+        args = pipe.source_client.create_or_replace_view.call_args.args
+        assert args[:3] == ("cat", "sch", "v_g")
+        assert "object_hash" in args[3]
 
 
 class TestCollectDomainStats:

--- a/tests/units/dtwin/test_build_pipeline_streaming.py
+++ b/tests/units/dtwin/test_build_pipeline_streaming.py
@@ -183,7 +183,7 @@ class TestApplyViaSyncedPipeline:
         assert ensure_kwargs["primary_key_columns"] == [
             "subject",
             "predicate",
-            "object",
+            "object_hash",
         ]
         assert ensure_kwargs["sync_mode"] == "snapshot"
         pipe.store.ensure_synced_companion.assert_called_once_with(pipe.graph_name)


### PR DESCRIPTION
## Summary

Patch release **v0.6.2** on top of v0.6.1:

- **Lakebase KG sync** — `object_hash` primary keys for long literal values (#108); scheduled managed_synced VIEW builds; idempotent Lakeflow `_sync` graph indexes (#112)
- **`object_hash` KG build fixes** — interactive managed_synced builds open the graph store before VIEW creation, refresh the Lakeflow source VIEW with `object_hash`, and auto-migrate legacy `__app` companion tables (fixes `column "object_hash" does not exist` on rebuild)
- **Agents** — flatten list-style `message.content` from Claude serving endpoints (#107, PR #109)
- **Performance** — Lakebase alias expansion groups large local-id LIKE sets into `RIGHT(subject, k) = ANY(...)` (PR #115)
- **UX** — edit-lock idle expiry shows a **Resume editing** button in the L2 subnav (tooltip) instead of a top banner
- **Developer** — pytest clears leaked `LAKEBASE_*` / `PG*` env vars; PAT deploy works with `DEFAULT_DATABRICKS_PROFILE=`

See `releases/ReleaseNotes_V0.6.2.md` for full details and upgrade notes (run a full KG rebuild after upgrade — legacy companions migrate automatically during the build).

## Test plan

- [x] `uv run pytest -q -m "not scenario"` → 3007 passed, 275 skipped
- [x] Smoke-test deployed app (`ontobricks-060` on `fe-vm-bcayla-demos`)
- [x] KG rebuild on managed_synced domain with legacy `__app` companion (local + deployed)
- [ ] Verify edit-lock resume button on idle expiry (L2 subnav, left of Save)
- [ ] KG rebuild on a domain with long literal properties (Lakebase backend)