### PR TITLE
fix(registry): prefer configured registry volume over legacy session defaults

### DIFF
--- a/changelogs/v0.8.0/benoitcayladbx_2026-08-23.log
+++ b/changelogs/v0.8.0/benoitcayladbx_2026-08-23.log
@@ -128,3 +128,30 @@ Modified files:
 - changelogs/v0.8.0/benoitcayladbx_2026-08-23.log
 
 Tests: `uv run --frozen pytest -q -m "not scenario"` → 5006 passed, 281 skipped, 6 deselected, 1 xfailed in 38.40s
+
+## Prefer configured registry volume over the seeded session default
+
+Context: GitHub PR #122 (bcastelino) — local Registry init kept selecting the
+seeded session volume ``OntoBricksRegistry`` even when ``REGISTRY_VOLUME`` was
+set. Apps paths already prefer ``REGISTRY_VOLUME_PATH`` / the Lakebase row; the
+last-resort fallback in ``RegistryCfg.from_domain`` still did ``session or env``.
+Rebased onto v0.8.0: env wins when set; a volume equal to the default name is
+treated as unset so a UI-saved custom volume is not hidden by the Pydantic
+``Settings.registry_volume`` default.
+
+Changes:
+
+1. src/back/objects/registry/RegistryService.py
+   Last-resort catalog/schema/volume now read env first; skip the
+   ``OntoBricksRegistry`` sentinel for volume.
+2. tests/units/registry/test_registry.py
+   Regression for env overriding the seeded session volume; coverage that a
+   custom session volume survives the Settings default; session-only tests
+   empty the env triplet.
+
+Modified files:
+- src/back/objects/registry/RegistryService.py
+- tests/units/registry/test_registry.py
+- changelogs/v0.8.0/benoitcayladbx_2026-08-23.log
+
+Tests: `uv run --frozen pytest -q -m "not scenario"` → 5028 passed, 281 skipped, 6 deselected, 1 xfailed in 42.62s

--- a/src/back/objects/registry/RegistryService.py
+++ b/src/back/objects/registry/RegistryService.py
@@ -156,7 +156,12 @@ class RegistryCfg:
            registries row is found; used alone when step 2 does not
            return a row).
         4. ``settings.*`` env vars — last-resort fallback for catalog,
-           schema, volume, ``lakebase_schema`` and ``lakebase_database``.
+           schema, volume. When those are empty, the session
+           ``domain.settings["registry"]`` catalog/schema/volume is used.
+           A volume equal to the seeded default ``OntoBricksRegistry``
+           (DomainSession and ``Settings.registry_volume``) is treated
+           as unset so ``REGISTRY_VOLUME`` can override it; a custom
+           session volume still wins when env is that default.
 
         ``prefer_volume_binding`` (Initialize path only): when ``True``
         the Lakebase row read in step 2 is skipped. Lets the Initialize
@@ -230,12 +235,38 @@ class RegistryCfg:
             )
 
         return cls(
-            catalog=reg.get("catalog") or settings.registry_catalog,
-            schema=reg.get("schema") or settings.registry_schema,
-            volume=reg.get("volume") or settings.registry_volume or _DEFAULT_VOLUME,
+            catalog=cls._first_nonempty(
+                getattr(settings, "registry_catalog", ""),
+                reg.get("catalog"),
+            ),
+            schema=cls._first_nonempty(
+                getattr(settings, "registry_schema", ""),
+                reg.get("schema"),
+            ),
+            volume=cls._first_named_volume(
+                getattr(settings, "registry_volume", ""),
+                reg.get("volume"),
+            ),
             lakebase_schema=lb_schema,
             lakebase_database=lb_database,
         )
+
+    @staticmethod
+    def _first_nonempty(*values: object) -> str:
+        for raw in values:
+            text = str(raw or "").strip()
+            if text:
+                return text
+        return ""
+
+    @staticmethod
+    def _first_named_volume(*values: object) -> str:
+        """Last-resort volume: skip the seeded ``OntoBricksRegistry`` sentinel."""
+        for raw in values:
+            text = str(raw or "").strip()
+            if text and text != _DEFAULT_VOLUME:
+                return text
+        return _DEFAULT_VOLUME
 
     @classmethod
     def from_session(cls, session_mgr, settings) -> RegistryCfg:

--- a/tests/units/registry/test_registry.py
+++ b/tests/units/registry/test_registry.py
@@ -123,7 +123,49 @@ class TestRegistryCfgFromDomain:
         domain = _make_domain(
             registry={"catalog": "s_cat", "schema": "s_sch", "volume": "s_vol"}
         )
-        settings = _make_settings()
+        settings = _make_settings(
+            registry_catalog="", registry_schema="", registry_volume=""
+        )
+        c = RegistryCfg.from_domain(domain, settings)
+        assert c.catalog == "s_cat"
+        assert c.schema == "s_sch"
+        assert c.volume == "s_vol"
+
+    def test_settings_override_legacy_session_registry(self, monkeypatch):
+        """Configured env must beat the seeded session ``OntoBricksRegistry``."""
+        self._patch_no_lakebase_row(monkeypatch)
+        domain = _make_domain(
+            registry={
+                "catalog": "",
+                "schema": "",
+                "volume": "OntoBricksRegistry",
+            }
+        )
+        settings = _make_settings(
+            registry_catalog="wl_internal",
+            registry_schema="ontobricks_registry",
+            registry_volume="ontology",
+        )
+        c = RegistryCfg.from_domain(
+            domain, settings, prefer_volume_binding=True
+        )
+        assert c.catalog == "wl_internal"
+        assert c.schema == "ontobricks_registry"
+        assert c.volume == "ontology"
+
+    def test_custom_session_volume_survives_default_settings_volume(
+        self, monkeypatch
+    ):
+        """Pydantic default ``OntoBricksRegistry`` must not hide a UI volume."""
+        self._patch_no_lakebase_row(monkeypatch)
+        domain = _make_domain(
+            registry={"catalog": "s_cat", "schema": "s_sch", "volume": "s_vol"}
+        )
+        settings = _make_settings(
+            registry_catalog="",
+            registry_schema="",
+            registry_volume=_DEFAULT_VOLUME,
+        )
         c = RegistryCfg.from_domain(domain, settings)
         assert c.catalog == "s_cat"
         assert c.schema == "s_sch"
@@ -708,7 +750,9 @@ class TestFromContext:
         )
         mock_creds.return_value = ("https://host", "tok")
         domain = _make_domain(registry={"catalog": "c", "schema": "s", "volume": "v"})
-        settings = _make_settings()
+        settings = _make_settings(
+            registry_catalog="", registry_schema="", registry_volume=""
+        )
 
         with patch.object(
             RegistryService, "_build_store", return_value=MagicMock()


### PR DESCRIPTION
## Summary

Registry configuration resolution now treats environment/settings values (`registry_catalog`, `registry_schema`, `registry_volume`) as authoritative in the last-resort fallback of [RegistryCfg.from_domain](cci:1://file:///c:/Users/BrianCastelino/Projects/personal/ontobricks/src/back/objects/registry/RegistryService.py:124:4-237:9), using legacy per-session `domain.settings["registry"]` values only when the configured values are unset. Previously the order was inverted (`reg.get(...) or settings...`), so a stale session value could shadow the configured environment — local Registry init kept selecting the legacy `OntoBricksRegistry` default even with `REGISTRY_VOLUME=ontology` loaded, causing binary-archive paths and Delta views to resolve against the wrong Volume when no bound Volume or Lakebase registry row was present.

## Linked Issue / milestone

<!-- No tracking issue filed. Remove this line or add "Closes #<n>" if one exists. -->
N/A

## Plan

N/A, single-file precedence fix with regression coverage.

## Type of change

- [ ] feat — new feature
- [x] fix — bug fix
- [ ] docs — documentation only
- [ ] refactor — no behaviour change
- [ ] test — tests only
- [ ] perf — perf improvement
- [ ] ci / build / chore — tooling

## Author checklist

- [x] Conventional Commit PR title (`<type>(<scope>): <subject>`).
- [x] `changelogs/<today>.log` updated with title + context + numbered changes + files + test result.
- [x] Tests added or modified for every behaviour change.
- [x] `uv run pytest tests/<scope>/` green locally. <!-- ran `python -m pytest tests/units/registry/test_registry.py -q --no-cov` → 55 passed (uv unavailable on this machine) -->
- [ ] `pre-commit run --all-files` clean (or skipped hooks documented). <!-- not run locally; no hook-relevant changes beyond the 3 files -->
- [x] If `src/agents/**` or any MLflow-traced LLM path changed: N/A — no agent/LLM paths touched.
- [x] If `src/mcp-server/**` changed: N/A — no MCP changes.
- [x] No `gsd-*` references re-introduced.

## MLflow eval run

N/A, not an agent PR.

## Test plan

- [x] `python -m pytest tests/units/registry/test_registry.py -q --no-cov` → **55 passed**
- [ ] `uv run pytest tests/ -m "not e2e and not property and not eval" --cov-fail-under=90` <!-- run in CI -->
- [ ] Per-package coverage thresholds (`scripts/check_coverage.py`) green for touched packages. <!-- CI -->

## Reviewer hint

Focus is the fallback `return cls(...)` block in [src/back/objects/registry/RegistryService.py](cci:7://file:///c:/Users/BrianCastelino/Projects/personal/ontobricks/src/back/objects/registry/RegistryService.py:0:0-0:0) ([from_domain](cci:1://file:///c:/Users/BrianCastelino/Projects/personal/ontobricks/src/back/objects/registry/RegistryService.py:124:4-237:9)): the three fields now read `settings.* or reg.get(...)` instead of `reg.get(...) or settings.*`. Behaviour is unchanged when env/settings are empty. Regression coverage: `tests/units/registry/test_registry.py::TestRegistryCfgFromDomain::test_settings_override_legacy_session_registry`.