### PR TITLE
fix(uc): backport hyphenated catalog name quoting to 0.6 (#124)

### DIFF
--- a/changelogs/v0.6.3/benoitcayladbx_2026-07-28.log
+++ b/changelogs/v0.6.3/benoitcayladbx_2026-07-28.log
@@ -1,0 +1,67 @@
+## Harden Unity Catalog SQL against identifier injection — backport (fixes #124)
+
+Context: Issue #124 reports that SQL queries fail for Unity Catalog names
+containing hyphens (e.g. `arc-dbx-uc-cdp`): Databricks SQL parses the hyphen as a
+minus operator, so `SHOW SCHEMAS IN arc-dbx-uc-cdp` is a parse error. Every
+metadata statement that interpolated a catalog/schema/table name directly into
+SQL was affected — SHOW SCHEMAS, SHOW TABLES, SHOW VOLUMES, DESCRIBE, the SELECT
+permission probe, and the `information_schema` queries.
+
+This was already fixed on develop (targeting v0.7.0) by the identifier-hardening
+pass, but the 0.6 line diverged from develop at `ea6ce28` on 2026-07-03 — two
+days *before* that fix landed — so no 0.6.x release contains it. Backported here
+as a cherry-pick of `b17c618`; the v0.7.0 changelog entry from that commit was
+dropped, and the identifier module keeps this line's pre-refactor layout
+(`src/back/core/uc_identifiers.py`, not `databricks/uc/identifiers.py`).
+
+Changes:
+
+1. src/back/core/uc_identifiers.py
+   New central module: `validate_uc_identifier` (allows letters, digits,
+   underscore and hyphen via `^[a-zA-Z_][a-zA-Z0-9_-]*$`, rejects `--`),
+   `quote_uc_identifier` (backtick-quotes a validated segment) and
+   `quote_uc_fqn` (quotes `catalog.schema[.table]`).
+2. src/back/core/databricks/UnityCatalog.py
+   Route every SQL path through those helpers: `get_schemas` (SHOW SCHEMAS),
+   `get_tables` (SHOW TABLES), `get_volumes` (SHOW VOLUMES), `get_table_columns`
+   (DESCRIBE), `check_table_select_permission` (SELECT … LIMIT 0), plus
+   `probe_schema_has_tables` and `get_table_comment`, which quote the catalog as
+   an identifier while keeping the schema/table as bound parameters in the
+   `WHERE` predicate.
+3. src/back/core/helpers/SQLHelpers.py
+   Expose the identifier helpers as `SQLHelpers` delegates so callers have one
+   entry point.
+4. src/back/core/databricks/DatabricksAuth.py
+   Incidental to this backport, not part of the #124 fix: `b17c618` also carried a
+   `_resolving_cloud_fetch` re-entrancy flag guarding
+   `_resolve_global_cloud_fetch_default`, which loads registry settings and could
+   otherwise recurse back into itself. Kept so the cherry-pick stays faithful and
+   this line does not retain a recursion bug already fixed on develop.
+5. tests/units/core/test_unity_catalog.py
+   Backported injection-guard coverage, plus a new `TestHyphenatedCatalogNames`
+   class that exercises the exact name from #124 (`arc-dbx-uc-cdp`) across SHOW
+   SCHEMAS / SHOW TABLES / SHOW VOLUMES / DESCRIBE / the SELECT probe and the
+   `information_schema` count, asserting the identifier is backtick-quoted and
+   the predicate value stays bound. All six fail against the unfixed file and
+   pass with the backport, so they reproduce the reported bug.
+6. tests/units/core/test_uri_sql_helpers.py
+   Cover the identifier helpers via the `SQLHelpers` delegates, including
+   `validate_uc_identifier("my-catalog")`.
+
+Known behavioural change: the validation regex requires a leading letter or
+underscore, so a catalog whose name starts with a digit now raises
+`ValidationError` instead of producing a SQL parse error. Unity Catalog does
+permit such names when quoted; this is a narrow edge case the hardening trades
+away and is unchanged from the develop implementation.
+
+Modified files:
+- src/back/core/uc_identifiers.py
+- src/back/core/databricks/UnityCatalog.py
+- src/back/core/helpers/SQLHelpers.py
+- src/back/core/databricks/DatabricksAuth.py
+- tests/units/core/test_unity_catalog.py
+- tests/units/core/test_uri_sql_helpers.py
+- changelogs/v0.6.3/benoitcayladbx_2026-07-28.log
+
+Tests: uv run pytest -q -m "not scenario" → 3027 passed, 286 skipped,
+5 deselected, 23 warnings in 22.03s.

--- a/src/back/core/databricks/DatabricksAuth.py
+++ b/src/back/core/databricks/DatabricksAuth.py
@@ -35,6 +35,7 @@ class DatabricksAuth:
 
     # Class-level cache: { (host, warehouse_id): (capable, reason, ts) }
     _cloud_fetch_cache: Dict[Tuple[str, str], Tuple[bool, str, float]] = {}
+    _resolving_cloud_fetch: bool = False
 
     @staticmethod
     def is_databricks_app() -> bool:
@@ -57,6 +58,9 @@ class DatabricksAuth:
     @staticmethod
     def _resolve_global_cloud_fetch_default(host: str, token: str) -> bool:
         """Best-effort load of global CloudFetch setting (default: enabled)."""
+        if DatabricksAuth._resolving_cloud_fetch:
+            return True
+        DatabricksAuth._resolving_cloud_fetch = True
         try:
             from shared.config.settings import get_settings
             from back.objects.registry import RegistryCfg
@@ -75,6 +79,8 @@ class DatabricksAuth:
                 exc,
             )
             return True
+        finally:
+            DatabricksAuth._resolving_cloud_fetch = False
 
     @staticmethod
     def get_workspace_host() -> str:

--- a/src/back/core/databricks/UnityCatalog.py
+++ b/src/back/core/databricks/UnityCatalog.py
@@ -11,6 +11,11 @@ from typing import Any, Dict, List
 
 from back.core.logging import get_logger
 from back.core.errors import ValidationError
+from back.core.uc_identifiers import (
+    quote_uc_fqn,
+    quote_uc_identifier,
+    validate_uc_identifier,
+)
 from shared.config.constants import MSG_WAREHOUSE_ID_REQUIRED
 from .DatabricksAuth import DatabricksAuth
 
@@ -55,11 +60,12 @@ class UnityCatalog:
     def get_schemas(self, catalog: str) -> List[str]:
         """Return schema names within *catalog*."""
         self._require_warehouse()
+        catalog_q = quote_uc_identifier(catalog, role="catalog")
         try:
             params = self._auth.get_sql_connection_params()
             with sql.connect(**params) as conn:
                 with conn.cursor() as cur:
-                    cur.execute(f"SHOW SCHEMAS IN {catalog}")
+                    cur.execute(f"SHOW SCHEMAS IN {catalog_q}")
                     return [row[0] for row in cur.fetchall()]
         except Exception as exc:
             logger.exception("Error fetching schemas: %s", exc)
@@ -71,11 +77,12 @@ class UnityCatalog:
         Returns an empty list on error (callers rely on this for graceful
         degradation).
         """
+        fqn = quote_uc_fqn(catalog, schema)
         try:
             params = self._auth.get_sql_connection_params()
             with sql.connect(**params) as conn:
                 with conn.cursor() as cur:
-                    cur.execute(f"SHOW TABLES IN {catalog}.{schema}")
+                    cur.execute(f"SHOW TABLES IN {fqn}")
                     return [row[1] for row in cur.fetchall()]
         except Exception as exc:
             logger.exception("Error fetching tables: %s", exc)
@@ -87,13 +94,16 @@ class UnityCatalog:
         Requires only USE SCHEMA — works even when SHOW TABLES returns empty
         due to missing SELECT grants on individual tables.  Returns -1 on error.
         """
+        catalog_q = quote_uc_identifier(catalog, role="catalog")
+        schema_val = validate_uc_identifier(schema, role="schema")
         try:
             params = self._auth.get_sql_connection_params()
             with sql.connect(**params) as conn:
                 with conn.cursor() as cur:
                     cur.execute(
-                        f"SELECT count(*) FROM {catalog}.information_schema.tables "
-                        f"WHERE table_schema = '{schema}' AND table_type = 'BASE TABLE'"
+                        f"SELECT count(*) FROM {catalog_q}.information_schema.tables "
+                        "WHERE table_schema = %s AND table_type = 'BASE TABLE'",
+                        (schema_val,),
                     )
                     row = cur.fetchone()
                     return int(row[0]) if row else 0
@@ -113,11 +123,12 @@ class UnityCatalog:
         - ``can_select`` (bool): True when the query succeeds
         - ``error`` (str | None): human-readable reason when can_select is False
         """
+        fqn = quote_uc_fqn(catalog, schema, table)
         try:
             params = self._auth.get_sql_connection_params()
             with sql.connect(**params) as conn:
                 with conn.cursor() as cur:
-                    cur.execute(f"SELECT * FROM {catalog}.{schema}.{table} LIMIT 0")
+                    cur.execute(f"SELECT * FROM {fqn} LIMIT 0")
             return {"can_select": True, "error": None}
         except Exception as exc:
             logger.info(
@@ -134,11 +145,12 @@ class UnityCatalog:
         Returns an empty list on error (callers rely on this for graceful
         degradation).
         """
+        fqn = quote_uc_fqn(catalog, schema, table)
         try:
             params = self._auth.get_sql_connection_params()
             with sql.connect(**params) as conn:
                 with conn.cursor() as cur:
-                    cur.execute(f"DESCRIBE {catalog}.{schema}.{table}")
+                    cur.execute(f"DESCRIBE {fqn}")
                     columns = []
                     for row in cur.fetchall():
                         columns.append(
@@ -155,17 +167,21 @@ class UnityCatalog:
 
     def get_table_comment(self, catalog: str, schema: str, table: str) -> str:
         """Return the table-level comment (empty string if none)."""
+        catalog_q = quote_uc_identifier(catalog, role="catalog")
+        catalog_val = validate_uc_identifier(catalog, role="catalog")
+        schema_val = validate_uc_identifier(schema, role="schema")
+        table_val = validate_uc_identifier(table, role="table")
         try:
             params = self._auth.get_sql_connection_params()
             with sql.connect(**params) as conn:
                 with conn.cursor() as cur:
                     query = (
-                        f"SELECT comment FROM {catalog}.information_schema.tables "
-                        f"WHERE table_catalog = '{catalog}' "
-                        f"AND table_schema = '{schema}' "
-                        f"AND table_name = '{table}'"
+                        f"SELECT comment FROM {catalog_q}.information_schema.tables "
+                        "WHERE table_catalog = %s "
+                        "AND table_schema = %s "
+                        "AND table_name = %s"
                     )
-                    cur.execute(query)
+                    cur.execute(query, (catalog_val, schema_val, table_val))
                     row = cur.fetchone()
                     return row[0] if row and row[0] else ""
         except Exception as exc:
@@ -175,11 +191,12 @@ class UnityCatalog:
     def get_volumes(self, catalog: str, schema: str) -> List[str]:
         """Return volume names via ``SHOW VOLUMES``."""
         self._require_warehouse()
+        fqn = quote_uc_fqn(catalog, schema)
         try:
             params = self._auth.get_sql_connection_params()
             with sql.connect(**params) as conn:
                 with conn.cursor() as cur:
-                    cur.execute(f"SHOW VOLUMES IN {catalog}.{schema}")
+                    cur.execute(f"SHOW VOLUMES IN {fqn}")
                     return [row[1] for row in cur.fetchall()]
         except Exception as exc:
             logger.exception("Error fetching volumes: %s", exc)

--- a/src/back/core/helpers/SQLHelpers.py
+++ b/src/back/core/helpers/SQLHelpers.py
@@ -24,6 +24,28 @@ class SQLHelpers:
         return str(value).replace("\\", "\\\\").replace("'", "''")
 
     @staticmethod
+    def validate_uc_identifier(name: str, *, role: str = "identifier") -> str:
+        from back.core.uc_identifiers import validate_uc_identifier
+
+        return validate_uc_identifier(name, role=role)
+
+    @staticmethod
+    def quote_uc_identifier(name: str, *, role: str = "identifier") -> str:
+        from back.core.uc_identifiers import quote_uc_identifier
+
+        return quote_uc_identifier(name, role=role)
+
+    @staticmethod
+    def quote_uc_fqn(
+        catalog: str,
+        schema: str,
+        table: str | None = None,
+    ) -> str:
+        from back.core.uc_identifiers import quote_uc_fqn
+
+        return quote_uc_fqn(catalog, schema, table)
+
+    @staticmethod
     def validate_table_name(table_name: str) -> None:
         """Raise :class:`~back.core.errors.ValidationError` if *table_name* is empty.
 

--- a/src/back/core/uc_identifiers.py
+++ b/src/back/core/uc_identifiers.py
@@ -1,0 +1,39 @@
+"""Unity Catalog SQL identifier validation (import-safe for databricks subpackage)."""
+
+from __future__ import annotations
+
+import re
+
+from back.core.errors import ValidationError
+
+# Unity Catalog segment names: letters, digits, underscore, hyphen; leading letter/underscore.
+UC_IDENTIFIER_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_-]*$")
+
+
+def validate_uc_identifier(name: str, *, role: str = "identifier") -> str:
+    """Return *name* when it is a safe Unity Catalog identifier segment."""
+    segment = (name or "").strip()
+    if not UC_IDENTIFIER_RE.match(segment) or "--" in segment:
+        raise ValidationError(f"Invalid UC {role}: {name!r}")
+    return segment
+
+
+def quote_uc_identifier(name: str, *, role: str = "identifier") -> str:
+    """Backtick-quote a validated Unity Catalog identifier."""
+    validated = validate_uc_identifier(name, role=role)
+    return f"`{validated}`"
+
+
+def quote_uc_fqn(
+    catalog: str,
+    schema: str,
+    table: str | None = None,
+) -> str:
+    """Return ``catalog.schema`` or ``catalog.schema.table`` with quoted segments."""
+    parts = [
+        quote_uc_identifier(catalog, role="catalog"),
+        quote_uc_identifier(schema, role="schema"),
+    ]
+    if table is not None:
+        parts.append(quote_uc_identifier(table, role="table"))
+    return ".".join(parts)

--- a/tests/units/core/test_unity_catalog.py
+++ b/tests/units/core/test_unity_catalog.py
@@ -91,7 +91,7 @@ class TestGetSchemas:
         uc = UnityCatalog(auth_with_warehouse)
         out = uc.get_schemas("main")
         assert out == ["default", "information_schema"]
-        mock_cursor.execute.assert_called_once_with("SHOW SCHEMAS IN main")
+        mock_cursor.execute.assert_called_once_with("SHOW SCHEMAS IN `main`")
 
 
 class TestGetTables:
@@ -105,7 +105,7 @@ class TestGetTables:
         uc = UnityCatalog(auth_with_warehouse)
         out = uc.get_tables("cat", "sch")
         assert out == ["t1", "t2"]
-        mock_cursor.execute.assert_called_once_with("SHOW TABLES IN cat.sch")
+        mock_cursor.execute.assert_called_once_with("SHOW TABLES IN `cat`.`sch`")
 
     @patch(
         "databricks.sql.connect",
@@ -134,7 +134,7 @@ class TestGetTableColumns:
             {"name": "name", "type": "string", "comment": ""},
             {"name": "x", "type": "int", "comment": ""},
         ]
-        mock_cursor.execute.assert_called_once_with("DESCRIBE cat.sch.tbl")
+        mock_cursor.execute.assert_called_once_with("DESCRIBE `cat`.`sch`.`tbl`")
 
     @patch(
         "databricks.sql.connect",
@@ -155,9 +155,11 @@ class TestGetTableComment:
         uc = UnityCatalog(auth_with_warehouse)
         assert uc.get_table_comment("cat", "sch", "tbl") == "my table comment"
         mock_cursor.execute.assert_called_once()
-        call_sql = mock_cursor.execute.call_args[0][0]
+        call_args = mock_cursor.execute.call_args
+        call_sql = call_args[0][0]
         assert "information_schema.tables" in call_sql
-        assert "cat" in call_sql and "sch" in call_sql and "tbl" in call_sql
+        assert "`cat`.information_schema.tables" in call_sql
+        assert call_args[0][1] == ("cat", "sch", "tbl")
 
     @patch("databricks.sql.connect")
     def test_returns_empty_when_no_row(self, mock_connect, auth_with_warehouse):
@@ -190,7 +192,7 @@ class TestGetVolumesSql:
         uc = UnityCatalog(auth_with_warehouse)
         out = uc.get_volumes("main", "default")
         assert out == ["vol_a", "vol_b"]
-        mock_cursor.execute.assert_called_once_with("SHOW VOLUMES IN main.default")
+        mock_cursor.execute.assert_called_once_with("SHOW VOLUMES IN `main`.`default`")
 
 
 class TestListVolumesRest:
@@ -272,3 +274,123 @@ class TestCreateVolumeRest:
         )
         uc = UnityCatalog(auth)
         assert uc.create_volume("main", "default", "v") is False
+
+
+class TestUnityCatalogSqlInjectionGuards:
+    @pytest.mark.parametrize(
+        "method,args",
+        [
+            ("get_schemas", ("main; DROP TABLE x--",)),
+            ("get_tables", ("cat", "sch'; DROP--")),
+            ("get_table_columns", ("cat", "sch", "tbl;drop")),
+            ("get_table_comment", ("cat", "sch", "tbl;")),
+            ("get_volumes", ("main", "default;")),
+            ("probe_schema_has_tables", ("cat", "sch;")),
+            ("check_table_select_permission", ("cat", "sch", "tbl;")),
+        ],
+    )
+    def test_rejects_invalid_identifiers(self, auth_with_warehouse, method, args):
+        uc = UnityCatalog(auth_with_warehouse)
+        with pytest.raises(ValidationError, match="Invalid UC"):
+            getattr(uc, method)(*args)
+
+
+class TestHyphenatedCatalogNames:
+    """Hyphenated catalog names must be backtick-quoted, not read as minus operators."""
+
+    CATALOG = "arc-dbx-uc-cdp"
+
+    @patch("databricks.sql.connect")
+    def test_show_schemas_quotes_catalog(self, mock_connect, auth_with_warehouse):
+        mock_cursor = _make_sql_mocks(mock_connect, fetchall=[["default"]])
+        uc = UnityCatalog(auth_with_warehouse)
+        assert uc.get_schemas(self.CATALOG) == ["default"]
+        mock_cursor.execute.assert_called_once_with(
+            "SHOW SCHEMAS IN `arc-dbx-uc-cdp`"
+        )
+
+    @patch("databricks.sql.connect")
+    def test_show_tables_quotes_catalog(self, mock_connect, auth_with_warehouse):
+        mock_cursor = _make_sql_mocks(mock_connect, fetchall=[["sch", "t1", "false"]])
+        uc = UnityCatalog(auth_with_warehouse)
+        assert uc.get_tables(self.CATALOG, "sales-eu") == ["t1"]
+        mock_cursor.execute.assert_called_once_with(
+            "SHOW TABLES IN `arc-dbx-uc-cdp`.`sales-eu`"
+        )
+
+    @patch("databricks.sql.connect")
+    def test_describe_quotes_full_fqn(self, mock_connect, auth_with_warehouse):
+        mock_cursor = _make_sql_mocks(mock_connect, fetchall=[["id", "bigint", ""]])
+        uc = UnityCatalog(auth_with_warehouse)
+        uc.get_table_columns(self.CATALOG, "sales-eu", "order-lines")
+        mock_cursor.execute.assert_called_once_with(
+            "DESCRIBE `arc-dbx-uc-cdp`.`sales-eu`.`order-lines`"
+        )
+
+    @patch("databricks.sql.connect")
+    def test_show_volumes_quotes_catalog(self, mock_connect, auth_with_warehouse):
+        mock_cursor = _make_sql_mocks(mock_connect, fetchall=[["sch", "vol_a"]])
+        uc = UnityCatalog(auth_with_warehouse)
+        assert uc.get_volumes(self.CATALOG, "default") == ["vol_a"]
+        mock_cursor.execute.assert_called_once_with(
+            "SHOW VOLUMES IN `arc-dbx-uc-cdp`.`default`"
+        )
+
+    @patch("databricks.sql.connect")
+    def test_information_schema_quotes_catalog_and_binds_value(
+        self, mock_connect, auth_with_warehouse
+    ):
+        mock_cursor = _make_sql_mocks(mock_connect, fetchone=[2])
+        uc = UnityCatalog(auth_with_warehouse)
+        assert uc.probe_schema_has_tables(self.CATALOG, "sales-eu") == 2
+        call_sql, params = mock_cursor.execute.call_args[0]
+        assert "`arc-dbx-uc-cdp`.information_schema.tables" in call_sql
+        # The schema is a value in the predicate, so it stays a bound parameter.
+        assert params == ("sales-eu",)
+
+    @patch("databricks.sql.connect")
+    def test_select_probe_quotes_full_fqn(self, mock_connect, auth_with_warehouse):
+        mock_cursor = _make_sql_mocks(mock_connect)
+        uc = UnityCatalog(auth_with_warehouse)
+        out = uc.check_table_select_permission(self.CATALOG, "sales-eu", "order-lines")
+        assert out == {"can_select": True, "error": None}
+        mock_cursor.execute.assert_called_once_with(
+            "SELECT * FROM `arc-dbx-uc-cdp`.`sales-eu`.`order-lines` LIMIT 0"
+        )
+
+
+class TestProbeSchemaHasTables:
+    @patch("databricks.sql.connect")
+    def test_returns_count_with_parameterized_query(self, mock_connect, auth_with_warehouse):
+        mock_cursor = _make_sql_mocks(mock_connect, fetchone=[3])
+        uc = UnityCatalog(auth_with_warehouse)
+        assert uc.probe_schema_has_tables("my_cat", "my_sch") == 3
+        mock_cursor.execute.assert_called_once()
+        call_sql, params = mock_cursor.execute.call_args[0]
+        assert "`my_cat`.information_schema.tables" in call_sql
+        assert "table_schema = %s" in call_sql
+        assert params == ("my_sch",)
+
+    @patch("databricks.sql.connect", side_effect=RuntimeError("denied"))
+    def test_returns_minus_one_on_error(self, _mock_connect, auth_with_warehouse):
+        uc = UnityCatalog(auth_with_warehouse)
+        assert uc.probe_schema_has_tables("cat", "sch") == -1
+
+
+class TestCheckTableSelectPermission:
+    @patch("databricks.sql.connect")
+    def test_uses_quoted_fqn(self, mock_connect, auth_with_warehouse):
+        mock_cursor = _make_sql_mocks(mock_connect)
+        uc = UnityCatalog(auth_with_warehouse)
+        out = uc.check_table_select_permission("cat", "sch", "tbl")
+        assert out == {"can_select": True, "error": None}
+        mock_cursor.execute.assert_called_once_with(
+            "SELECT * FROM `cat`.`sch`.`tbl` LIMIT 0"
+        )
+
+    @patch("databricks.sql.connect", side_effect=RuntimeError("no select"))
+    def test_returns_false_on_error(self, _mock_connect, auth_with_warehouse):
+        uc = UnityCatalog(auth_with_warehouse)
+        out = uc.check_table_select_permission("cat", "sch", "tbl")
+        assert out["can_select"] is False
+        assert "no select" in out["error"]

--- a/tests/units/core/test_uri_sql_helpers.py
+++ b/tests/units/core/test_uri_sql_helpers.py
@@ -73,6 +73,17 @@ class TestSQLHelpers:
         with pytest.raises(ValidationError):
             SQLHelpers.validate_table_name("   ")
 
+    def test_validate_uc_identifier_accepts_hyphen(self):
+        assert SQLHelpers.validate_uc_identifier("my-catalog", role="catalog") == "my-catalog"
+
+    def test_validate_uc_identifier_rejects_injection(self):
+        from back.core.errors import ValidationError
+        with pytest.raises(ValidationError, match="Invalid UC catalog"):
+            SQLHelpers.validate_uc_identifier("cat; DROP", role="catalog")
+
+    def test_quote_uc_fqn(self):
+        assert SQLHelpers.quote_uc_fqn("main", "default", "tbl") == "`main`.`default`.`tbl`"
+
     def test_effective_view_table_from_domain(self):
         class FakeDomain:
             delta = {"catalog": "cat", "schema": "sch"}


### PR DESCRIPTION
Backport of the Unity Catalog identifier hardening to the **0.6 line**. Base is `0.6.3`, not `develop`.

Fixes #124 for 0.6.x.

## Why this is needed

Catalog names containing hyphens (e.g. `arc-dbx-uc-cdp`) make Databricks SQL parse the hyphen as a minus operator, so `SHOW SCHEMAS IN arc-dbx-uc-cdp` is a parse error. Every metadata statement that interpolated an identifier straight into SQL was affected.

This was already fixed on `develop` (targeting 0.7.0) by `b17c618`, but the 0.6 line diverged from `develop` at `ea6ce28` on 2026-07-03 — **two days before that fix landed**. So although `v0.6.3` is tagged later (2026-07-16), it does not contain the fix, and users upgrading from 0.5.2 to any current 0.6.x still hit the bug.

## Changes

Cherry-pick of `b17c618`, with the source layout kept at this line's pre-refactor path (`src/back/core/uc_identifiers.py`, not `databricks/uc/identifiers.py`).

- **`src/back/core/uc_identifiers.py`** (new) — `validate_uc_identifier` (allows letters, digits, underscore and hyphen via `^[a-zA-Z_][a-zA-Z0-9_-]*$`, rejects `--`), `quote_uc_identifier`, `quote_uc_fqn`.
- **`src/back/core/databricks/UnityCatalog.py`** — routes `SHOW SCHEMAS`, `SHOW TABLES`, `SHOW VOLUMES`, `DESCRIBE`, the `SELECT … LIMIT 0` probe, and the `information_schema` queries through those helpers. The `information_schema` paths quote the catalog as an identifier while keeping schema/table as **bound parameters** in the `WHERE` predicate.
- **`src/back/core/helpers/SQLHelpers.py`** — exposes the helpers as delegates.
- **`src/back/core/databricks/DatabricksAuth.py`** — see caveat below.

`list_functions` does not exist on this line, so there was no additional SQL path to cover beyond what the original fix touched. Verified no raw identifier interpolation remains in the file.

The original commit's `changelogs/v0.7.0/` entry was dropped (it does not belong on the 0.6 line) in favour of a `changelogs/v0.6.3/` entry.

## Tests

New `TestHyphenatedCatalogNames` exercises the exact catalog name from the report across all six affected paths. These are **not vacuous** — all six fail against the unfixed file and pass with this change, so they reproduce the reported bug:

```
FAILED tests/units/core/test_unity_catalog.py::TestHyphenatedCatalogNames::test_show_schemas_quotes_catalog
FAILED ... ::test_show_tables_quotes_catalog
FAILED ... ::test_describe_quotes_full_fqn
FAILED ... ::test_show_volumes_quotes_catalog
FAILED ... ::test_information_schema_quotes_catalog_and_binds_value
FAILED ... ::test_select_probe_quotes_full_fqn
```

Full suite: `uv run pytest -q -m "not scenario"` → **3027 passed, 286 skipped, 5 deselected**. Ruff counts are identical to baseline (32 before, 32 after), so no new lint was introduced.

## Two things for the reviewer

1. **Unrelated hunk carried by the cherry-pick.** `DatabricksAuth.py` gains a `_resolving_cloud_fetch` re-entrancy guard on `_resolve_global_cloud_fetch_default`, which loads registry settings and could otherwise recurse into itself. Nothing to do with hyphens. Kept so the cherry-pick stays faithful and this line does not retain a recursion bug already fixed on `develop`. Happy to strip it for a hyphen-only backport.

2. **Behavioural change.** The validation regex requires a leading letter or underscore, so a catalog whose name *starts with a digit* now raises `ValidationError` instead of producing a SQL parse error. Unity Catalog does permit such names when quoted; this is a narrow edge case the hardening trades away, and it is unchanged from the `develop` implementation.

Changelog went under `changelogs/v0.6.3/` because that is what `pyproject.toml` reports on this branch. If this ships as 0.6.4, the version bump and folder move are a release call I left alone.