### PR TITLE
fix(ci): pin databricks/setup-cli to v1.10.0 SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,10 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install Databricks CLI
-        uses: databricks/setup-cli@main
+        # Pin to v1.10.0 commit SHA — never @main next to DATABRICKS_TOKEN
+        uses: databricks/setup-cli@8821c27b1fe57472264eeb6e50c1f31d69552f28 # v1.10.0
+        with:
+          version: "1.10.0"
 
       - name: Validate bundle configuration
         run: databricks bundle validate

--- a/changelogs/v0.7.0/benoitcayladbx_2026-08-08.log
+++ b/changelogs/v0.7.0/benoitcayladbx_2026-08-08.log
@@ -99,3 +99,27 @@ Tests: `.venv/bin/pytest -q -m "not scenario"`
 → 4787 passed, 276 skipped, 5 deselected, 1 xfailed, 23 warnings in 32.42s.
 (`uv run --frozen` could not re-resolve hatchling against the internal pypi
 proxy in this environment — 403 — so the already-synced venv was used.)
+
+## Pin databricks/setup-cli away from @main in release.yml
+
+Context: Supply-chain audit (2026-08-04): `release.yml` ran
+`databricks/setup-cli@main` in the same job as `DATABRICKS_TOKEN`. `@main`
+is a mutable branch ref; a retargeted action could exfiltrate the token.
+Pin to the v1.10.0 commit SHA and pass an explicit CLI `version:` before
+Actions/secrets are re-enabled.
+
+Changes:
+
+1. `.github/workflows/release.yml`
+   Replace `databricks/setup-cli@main` with
+   `databricks/setup-cli@8821c27b1fe57472264eeb6e50c1f31d69552f28` (# v1.10.0)
+   and `with.version: "1.10.0"`.
+
+Modified files:
+- .github/workflows/release.yml
+- changelogs/v0.7.0/benoitcayladbx_2026-08-08.log
+
+Tests: `.venv/bin/pytest -q -m "not scenario"`
+→ 4787 passed, 276 skipped, 5 deselected, 1 xfailed, 23 warnings in 40.39s.
+(`uv run --frozen` blocked by pypi-proxy 403 in this environment — used
+already-synced `.venv`.)


### PR DESCRIPTION
## Summary
- Pins `databricks/setup-cli@main` → commit `8821c27…` (`v1.10.0`) in `release.yml`, with explicit `version: "1.10.0"`.
- Closes the audit finding that a mutable branch ref ran in the same job as `DATABRICKS_TOKEN` (pre-req before re-enabling Actions / provisioning secrets).

## Test plan
- [x] `.venv/bin/pytest -q -m "not scenario"` → 4787 passed
- [ ] CODEOWNERS review (ruleset requires it)
- [ ] After merge: no further action until secrets are provisioned; then dry-run `release.yml` via `workflow_dispatch` if desired