### PR TITLE
v0.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@
   <img src="https://img.shields.io/badge/fastapi-0.109+-green.svg" alt="FastAPI">
 </p>
 
-**Website:** [https://databrickslabs.github.io/ontobricks/](https://databrickslabs.github.io/ontobricks/)
-
 ## Project Description
 
 OntoBricks is a web application that transforms Databricks tables into a materialized graph viewer. It lets you design ontologies (OWL), map them to Unity Catalog tables via R2RML, materialize triples into a Delta-backed triple store and a Lakebase Postgres graph engine, reason over the graph (OWL 2 RL, SWRL, SHACL), and query it through an auto-generated GraphQL API. The entire pipeline — from metadata import to a queryable graph viewer — can run in four clicks using LLM-powered automation.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="src/front/static/global/img/ontobricks-icon.svg" alt="OntoBricks Logo" width="120" height="120">
 </p>
 
-<h1 align="center">OntoBricks 0.7.0</h1>
+<h1 align="center">OntoBricks 0.7.1</h1>
 
 <p align="center">
   <strong>Knowledge Graph Builder for Databricks</strong>

--- a/app.yaml.template
+++ b/app.yaml.template
@@ -162,15 +162,15 @@ env:
   # or above the node count makes them exact instead of estimated.
   - name: ONTOBRICKS_ANALYTICS_JOB_PIVOTS
     value: "64"
-  # ── Neo4j (optional) ──────────────────────────────────────────
-  # Password sourced from a Databricks Apps secret resource (see
+  # ── Neo4j (optional, legacy Apps secret path) ─────────────────
+  # Password may be sourced from a Databricks Apps secret resource (see
   # `resources:` below). The `neo4j-password` resource is unbound by
-  # default; the admin binds it to a workspace secret (scope/key) in
-  # the Apps UI before selecting the Neo4j engine. When the resource
-  # is unbound, NEO4J_PASSWORD stays unset and the deployed app refuses
-  # to instantiate Neo4jStore with a clear instruction in the logs.
-  # Local dev keeps the legacy fallback to engine_config['password'].
-  # See docs/v0.6-neo4j-demo/secret-configuration.md.
+  # default — DAB does **not** bind it at deploy time (Neo4j is optional;
+  # a missing workspace secret would fail terraform apply — GH #136).
+  # Preferred path: Settings → Neo4j picks a secret scope/key at runtime
+  # (`auth_method: databricks_secret`). Bind this resource in the Apps UI
+  # only for legacy `auth_method: basic` + `NEO4J_PASSWORD` configs.
+  # See documentation/pr47-neo4j-demo/secret-configuration.md.
   - name: NEO4J_PASSWORD
     valueFrom: neo4j-password
 
@@ -200,6 +200,6 @@ resources:
     volume:
       permission: CAN_READ_WRITE
   - name: neo4j-password
-    description: "Databricks Apps secret holding the Neo4j Bolt password. Unbound by default; bind it to a workspace secret (scope/key) in the Apps UI before activating the Neo4j engine. See docs/v0.6-neo4j-demo/secret-configuration.md."
+    description: "Legacy Databricks Apps secret for NEO4J_PASSWORD. Unbound by default — DAB does not bind it (GH #136). Prefer Settings → Neo4j (secret scope/key). Bind in the Apps UI only for legacy auth_method basic. See documentation/pr47-neo4j-demo/secret-configuration.md."
     secret:
       permission: READ

--- a/app.yaml.template
+++ b/app.yaml.template
@@ -77,6 +77,12 @@ env:
   # alias chain on ONTOBRICKS_APP_NAME -> DATABRICKS_APP_NAME, so the
   # same app.yaml powers every deployment without per-app duplication.
   # Set ONTOBRICKS_APP_NAME explicitly in .env only for local dev.
+  #
+  # MCP companion app name — must match the deployed MCP Databricks App
+  # (``mcp-${APP_NAME}`` from deploy.config.sh). Injected so registry /
+  # graph permission grants resolve the right service principal (#137).
+  - name: MCP_APP_NAME
+    value: "${MCP_APP_NAME}"
   # ── Lakebase (optional) ───────────────────────────────────────
   # When the bundle is deployed to a *-lakebase target the DAB binds
   # a `database` resource to this app. Databricks Apps then

--- a/changelogs/v0.7.0/benoitcayladbx_2026-08-12.log
+++ b/changelogs/v0.7.0/benoitcayladbx_2026-08-12.log
@@ -1,0 +1,38 @@
+## Fix deploy onboarding bugs #133 #134 #135
+
+Context: External reporter (iduarteandeco) hit three first-time deploy
+blockers on 0.7.0: setup-lakebase path after the scripts/bootstrap reorg,
+vague DAB app permissions docs that put CAN_USE at bundle top-level, and
+stale DEFAULT_LAKEBASE_DATABASE_RESOURCE_SEGMENT docs after the segment
+became auto-resolved. Fixes applied on branch 0.7.1 (and develop).
+
+Changes:
+
+1. scripts/bootstrap/setup-lakebase.sh
+   cd to repo root (../..) and document DEFAULT_LAKEBASE_DATABASE + optional
+   LAKEBASE_DATABASE_RESOURCE_SEGMENT instead of removed DEFAULT_* segment.
+2. scripts/bootstrap/app-permissions.sh
+   Same repo-root cd so scripts/deploy.config.sh resolves (#133).
+3. scripts/bootstrap/lakebase-perms.sh
+   Same repo-root cd (#133).
+4. databricks.yml
+   Nest CAN_MANAGE / CAN_USE under resources.apps.* for both apps (#134).
+5. documentation/deployment.md
+   Clarify app-level permissions nesting; replace stale DEFAULT_LAKEBASE_*
+   names with DEFAULT_LAKEBASE_DATABASE / _SCHEMA + optional segment override.
+6. documentation/lakebase-graphdb.md
+   Same variable/docs alignment as deployment.md (#135).
+7. tests/units/settings/test_bundle_job_resource.py
+   Regression guards for bootstrap repo-root climb and app permissions nesting.
+
+Modified files:
+- scripts/bootstrap/setup-lakebase.sh
+- scripts/bootstrap/app-permissions.sh
+- scripts/bootstrap/lakebase-perms.sh
+- databricks.yml
+- documentation/deployment.md
+- documentation/lakebase-graphdb.md
+- tests/units/settings/test_bundle_job_resource.py
+- changelogs/v0.7.0/benoitcayladbx_2026-08-12.log
+
+Tests: uv run --frozen pytest -q -m "not scenario" → 4793 passed, 276 skipped, 5 deselected, 1 xfailed in 41.08s

--- a/changelogs/v0.7.1/benoitcayladbx_2026-08-12.log
+++ b/changelogs/v0.7.1/benoitcayladbx_2026-08-12.log
@@ -1,0 +1,42 @@
+## Stop binding Neo4j secret in DAB deploy (GH #136)
+
+Context: `./scripts/deploy.sh` failed on first deploy with
+`Invalid secret resource neo4j-password: Secret with scope ontobricks-secrets
+and key neo4j-password does not exist.` Neo4j is optional and the product path
+is Settings → Neo4j (Secrets API); the DAB overlay forced a workspace secret
+that most installs do not have. Also, instance targets (`dev-lakebase-<id>`)
+skipped the secret preflight because it only grepped `databricks.yml`.
+
+Changes:
+
+1. `databricks.yml`
+   Removed `neo4j_secret_scope` variable and the `neo4j-password` secret overlay
+   from the `dev-lakebase` app resources.
+2. `scripts/_internal/_ensure-instance-target.sh`
+   Stopped emitting the `neo4j-password` secret binding for generated instance
+   targets.
+3. `scripts/deploy.config.sh` / `scripts/deploy.sh`
+   Dropped `NEO4J_SECRET_SCOPE` / `--var=neo4j_secret_scope` and the secret-scope
+   preflight block.
+4. `app.yaml.template`
+   Clarified that the unbound `neo4j-password` resource is legacy-only and not
+   bound by DAB.
+5. `tests/units/settings/test_deploy_app_rename_guard.py`
+   Replaced “secret scope is configurable” assertions with “DAB must not bind
+   Neo4j secrets”.
+6. `documentation/pr47-neo4j-demo/secret-configuration.md` /
+   `documentation/deployment.md`
+   Documented that deploy does not bind Neo4j secrets.
+
+Modified files:
+- databricks.yml
+- scripts/_internal/_ensure-instance-target.sh
+- scripts/deploy.config.sh
+- scripts/deploy.sh
+- app.yaml.template
+- tests/units/settings/test_deploy_app_rename_guard.py
+- documentation/pr47-neo4j-demo/secret-configuration.md
+- documentation/deployment.md
+- changelogs/v0.7.1/benoitcayladbx_2026-08-12.log
+
+Tests: uv run --frozen pytest -q -m "not scenario" → 4796 passed, 276 skipped, 5 deselected, 1 xfailed in 45.53s

--- a/changelogs/v0.7.1/benoitcayladbx_2026-08-14.log
+++ b/changelogs/v0.7.1/benoitcayladbx_2026-08-14.log
@@ -1,0 +1,45 @@
+## Fix MCP SP resolution + UC grants on first deploy (#137)
+
+Context: After `./scripts/deploy.sh` with instance-suffixed apps
+(`ontobricks-07x` / `mcp-ontobricks-07x`), Registry → Initialize looked up
+the bare `mcp-ontobricks` name and skipped MCP grants. Control-plane
+re-grants (`CAN_USE` / UC `ALL_PRIVILEGES`) also warned because the app SP
+lacks MANAGE, and UC catalog grants in `lakebase-perms.sh` ran only after
+the schema-existence guard — so a first deploy exited before granting them.
+
+Changes:
+
+1. src/back/core/databricks/lakebase/grants.py
+   Added `resolve_mcp_app_name` (`mcp-{APP_NAME}`, matching deploy.config.sh);
+   clarified CAN_USE / UC warning text to point at bootstrap instead of
+   implying privileges are missing.
+2. src/back/core/databricks/lakebase/__init__.py
+   Re-exported `resolve_mcp_app_name`.
+3. src/back/objects/domain/SettingsService.py
+   Registry + graph provision grant lists now use `resolve_mcp_app_name`.
+4. app.yaml.template
+   Inject `MCP_APP_NAME` into the running app env at deploy time.
+5. scripts/bootstrap/lakebase-perms.sh
+   Move UC catalog `ALL_PRIVILEGES` grants before the schema-existence
+   guard so first deploy still applies them.
+6. src/front/templates/settings.html
+   Clear hardcoded `mcp-ontobricks` default on the graph-provision MCP
+   field so blank derives `mcp-{main app}`.
+7. documentation/deployment.md
+   Document MCP naming, first-deploy UC grant timing, and why elevating
+   the app SP to CAN_MANAGE is the wrong fix.
+8. tests/units/settings/test_mcp_app_name_resolution.py
+   Unit coverage for MCP name derivation and registry grant app list.
+
+Modified files:
+- src/back/core/databricks/lakebase/grants.py
+- src/back/core/databricks/lakebase/__init__.py
+- src/back/objects/domain/SettingsService.py
+- app.yaml.template
+- scripts/bootstrap/lakebase-perms.sh
+- src/front/templates/settings.html
+- documentation/deployment.md
+- tests/units/settings/test_mcp_app_name_resolution.py
+- changelogs/v0.7.1/benoitcayladbx_2026-08-14.log
+
+Tests: uv run --frozen pytest -q -m "not scenario" → 4798 passed, 276 skipped, 5 deselected, 1 xfailed in 40.06s

--- a/changelogs/v0.7.1/benoitcayladbx_2026-08-19.log
+++ b/changelogs/v0.7.1/benoitcayladbx_2026-08-19.log
@@ -1,0 +1,46 @@
+## Align e2e Home / Explorer assertions with current UI
+
+Context: Explicit `pytest tests/e2e` (no auto-skip) failed three assertions
+left over from the old Home KPI/workflow-card layout and the Knowledge Graph
+sidebar rename to "Explorer".
+
+Changes:
+
+1. tests/e2e/dtwin/test_dtwin_flows.py
+   Accept "Explorer" as the sigmagraph sidebar label.
+2. tests/e2e/navigation/test_navigation_flows.py
+   Replace stale `.workflow-card` / `#classCount` checks with All Domains
+   gateway + New Domain CTA assertions.
+
+Modified files:
+- tests/e2e/dtwin/test_dtwin_flows.py
+- tests/e2e/navigation/test_navigation_flows.py
+- changelogs/v0.7.1/benoitcayladbx_2026-08-19.log
+
+Tests: e2e `uv run --frozen pytest tests/e2e -q --ignore=tests/e2e/scenarios` → 258 passed in 118.78s; unit `uv run --frozen pytest -q -m "not scenario and not e2e and not live_integration"` → 4798 passed, 280 deselected, 1 xfailed in 33.98s
+
+## Fix temporal-predicate false positives (remove xfail)
+
+Context: `has_temporal_predicates` matched keywords as bare substrings, so
+short tokens like `dt` / `at` fired inside `assignedTo` / `locatedIn`. The
+suite carried a strict xfail for that false positive.
+
+Changes:
+
+1. src/back/core/graph_analysis/profiles.py
+   Match temporal keywords as whole camelCase / snake_case tokens.
+2. src/back/core/graph_analysis/models.py
+   Docstring aligned with token matching.
+3. tests/units/core/test_profiles.py
+   Drop `@pytest.mark.xfail`; cover `assignedTo` / `locatedIn` / `status`.
+4. documentation/user-guide.md
+   Temporal profile wording updated to token matching.
+
+Modified files:
+- src/back/core/graph_analysis/profiles.py
+- src/back/core/graph_analysis/models.py
+- tests/units/core/test_profiles.py
+- documentation/user-guide.md
+- changelogs/v0.7.1/benoitcayladbx_2026-08-19.log
+
+Tests: uv run --frozen pytest -q -m "not scenario and not e2e and not live_integration" → 4799 passed, 280 deselected, 23 warnings in 32.89s (0 xfailed)

--- a/databricks.yml
+++ b/databricks.yml
@@ -209,6 +209,12 @@ resources:
       name: "${var.app_name}"
       description: "OntoBricks (development sandbox app)"
       source_code_path: .
+      # App ACL (not top-level bundle permissions — those reject CAN_USE; see #134).
+      permissions:
+        - level: CAN_MANAGE
+          user_name: ${workspace.current_user.userName}
+        - level: CAN_USE
+          group_name: users
       resources:
         - name: sql-warehouse
           description: "SQL Warehouse for executing queries and metadata operations"
@@ -233,6 +239,12 @@ resources:
       name: "${var.mcp_app_name}"
       description: "OntoBricks MCP companion server (FastMCP)"
       source_code_path: ./src/mcp-server
+      # App ACL (not top-level bundle permissions — those reject CAN_USE; see #134).
+      permissions:
+        - level: CAN_MANAGE
+          user_name: ${workspace.current_user.userName}
+        - level: CAN_USE
+          group_name: users
       resources:
         - name: sql-warehouse
           description: "SQL Warehouse for executing queries and metadata operations"

--- a/databricks.yml
+++ b/databricks.yml
@@ -122,14 +122,6 @@ variables:
     description: "Volume name for the domain registry"
     default: "registry"
 
-  # Workspace secret scope holding ``neo4j-password``. A scope that does not
-  # exist fails ``terraform apply`` on the app resource, so keep this pointed at
-  # a real scope (``databricks secrets list-scopes``) or drop the overlay in the
-  # target below.
-  neo4j_secret_scope:
-    description: "Workspace secret scope holding the Neo4j Bolt password"
-    default: "ontobricks-secrets"
-
   # ── Lakebase resource binding (Autoscaling-only) ────────────────
   # OntoBricks targets **Lakebase Autoscaling** exclusively (the
   # default tier for every instance created after 2026-03-12). The
@@ -292,17 +284,13 @@ targets:
                 branch: projects/${var.lakebase_project}/branches/${var.lakebase_branch}
                 database: projects/${var.lakebase_project}/branches/${var.lakebase_branch}/databases/${var.lakebase_database_resource_segment}
                 permission: "CAN_CONNECT_AND_CREATE"
-            # Neo4j Bolt password — bound to a workspace secret on deploy.
-            # Customer admins can switch to manual UI binding by removing
-            # this overlay (the resource declaration still lives in
-            # ``app.yaml.template``, unbound by default).
+            # Neo4j is optional and configured post-deploy in Settings → Neo4j
+            # (Databricks secret scope/key at runtime). Do NOT bind an Apps
+            # secret resource here — a missing workspace secret fails
+            # ``terraform apply`` on first deploy (GH #136). The unbound
+            # ``neo4j-password`` declaration in ``app.yaml.template`` remains
+            # for legacy ``NEO4J_PASSWORD`` / Apps UI binding only.
             # See documentation/pr47-neo4j-demo/secret-configuration.md.
-            - name: neo4j-password
-              description: "Databricks Apps secret holding the Neo4j Bolt password"
-              secret:
-                scope: ${var.neo4j_secret_scope}
-                key: neo4j-password
-                permission: READ
         mcp_ontobricks_app:
           resources:
             - name: postgres

--- a/documentation/deployment.md
+++ b/documentation/deployment.md
@@ -628,30 +628,39 @@ or a manual `bootstrap-lakebase-perms.sh` run.
 
 The script grants:
 
-1. `CAN_USE` on the Lakebase database instance (control-plane).
-2. `USAGE + CREATE` on the Postgres schema.
-3. `SELECT / INSERT / UPDATE / DELETE` on every existing table.
-4. `USAGE / SELECT / UPDATE` on every existing sequence (bigserial PKs).
-5. The same set via `ALTER DEFAULT PRIVILEGES` so future tables inherit.
+1. `CAN_USE` on the Lakebase database project (control-plane).
+2. `ALL PRIVILEGES` on the UC catalog when `-c/--catalog` is passed
+   (also control-plane — applied **before** the schema exists so a
+   first deploy still grants it; `deploy.sh` passes `-c $REGISTRY_CATALOG`).
+3. `USAGE + CREATE` on the Postgres schema.
+4. `SELECT / INSERT / UPDATE / DELETE` on every existing table.
+5. `USAGE / SELECT / UPDATE` on every existing sequence (bigserial PKs).
+6. The same set via `ALTER DEFAULT PRIVILEGES` so future tables inherit.
+
+> **Naming:** pass the real MCP app name (`mcp-${APP_NAME}`, e.g.
+> `mcp-ontobricks-07x`), not the bare `mcp-ontobricks` string. Instance
+> deploys derive both names from `DEFAULT_INSTANCE_ID` in
+> `scripts/deploy.config.sh`.
 
 Manual invocation:
 
 ```bash
-# Registry schema
+# Registry schema (use your APP_NAME / MCP_APP_NAME from deploy.config.sh)
 scripts/bootstrap/lakebase-perms.sh \
   -i "<lakebase_project>" \
   -b "<lakebase_branch>" \
   -d ontobricks_registry \
   -s ontobricks_registry \
+  -c "<registry_catalog>" \
   -a ontobricks-XXX \
-  -a mcp-ontobricks
+  -a mcp-ontobricks-XXX
 
 # Graph schema (run after first Build — use the graph DB's own
 # project/branch/database, which MAY differ from the registry)
 scripts/bootstrap/lakebase-perms.sh \
   -i "<graph_project>" -b "<graph_branch>" \
   -d "<graph_database>" -s ontobricks_graph \
-  -a ontobricks-XXX -a mcp-ontobricks
+  -a ontobricks-XXX -a mcp-ontobricks-XXX
 ```
 
 The registry grant uses `LAKEBASE_PROJECT` / `LAKEBASE_BRANCH` /
@@ -697,10 +706,16 @@ If the volume is empty (first deployment):
 1. Open the app URL
 2. Go to **Settings > Registry**
 3. Click **Initialize** to bootstrap the registry — on the Lakebase
-   backend this also self-applies the schema/project/UC grants the app +
+   backend this also self-applies the **Postgres schema** grants the app +
    MCP service principals need (results shown under **Permission Grants**).
+   Control-plane re-grants (`CAN_USE` on the Lakebase project, UC
+   `ALL_PRIVILEGES` on the catalog) are best-effort: the app SP usually
+   lacks `CAN_MANAGE` / catalog `MANAGE`, so those lines may warn even
+   when deploy already applied them. If UC privileges are actually
+   missing, re-run `scripts/bootstrap/lakebase-perms.sh` with `-c` as a
+   workspace admin (do **not** need to elevate the app SP to `CAN_MANAGE`).
    Use **Repair permissions** on the Lakebase Connection panel to re-apply
-   them later (e.g. after a rebind).
+   schema grants later (e.g. after a rebind).
 
 ### Step 9 — Verify
 
@@ -893,6 +908,21 @@ GRANT ALL PRIVILEGES ON SCHEMA  `<registry_catalog>`.`<registry_schema>` TO `<ap
 ```
 
 Prefer the explicit list above for a production workspace because `ALL PRIVILEGES` also implies `MANAGE`, which is broader than what the app needs day to day.
+
+> **Lakebase / Initialize note (issue #137):** the in-app *Initialize* /
+> *Repair permissions* flow also tries to grant catalog-level
+> `ALL_PRIVILEGES` to the app SP so synced tables are readable. That call
+> runs **as the app SP**, which cannot succeed unless the SP already has
+> catalog `MANAGE`. Prefer granting `ALL PRIVILEGES` **to** the SP from a
+> human/admin principal via `scripts/bootstrap/lakebase-perms.sh -c
+> <catalog>` (or the SQL below) — do **not** elevate the app SP to
+> `CAN_MANAGE` / catalog `MANAGE` just to silence the Initialize warning.
+>
+> ```sql
+> GRANT ALL PRIVILEGES ON CATALOG `<registry_catalog>` TO `<app-sp>`;
+> -- repeat for the MCP app SP
+> GRANT ALL PRIVILEGES ON CATALOG `<registry_catalog>` TO `<mcp-sp>`;
+> ```
 
 ### 3.3 — Source data grants (customer tables/views)
 

--- a/documentation/deployment.md
+++ b/documentation/deployment.md
@@ -399,7 +399,7 @@ Deployment uses **Databricks Asset Bundles** to deploy both the main app and the
 | SQL Warehouse | A running SQL Warehouse in the workspace |
 | Apps feature | Databricks Apps must be enabled on the workspace |
 | Unity Catalog | A catalog, schema, and volume for the project registry |
-| **Lakebase project** | Must be provisioned via `scripts/bootstrap/setup-lakebase.sh` — **do not** use the Databricks UI "New project" button (calls wrong API, incompatible with Synced Tables). The script uses `POST /api/2.0/database/instances` and prints the `db-…` resource id to put in `scripts/deploy.config.sh > DEFAULT_LAKEBASE_DATABASE_RESOURCE_SEGMENT`. See §2a below. |
+| **Lakebase project** | Must be provisioned via `scripts/bootstrap/setup-lakebase.sh` — **do not** use the Databricks UI "New project" button (calls wrong API, incompatible with Synced Tables). The script uses `POST /api/2.0/database/instances` and prints the `db-…` resource id. Set `DEFAULT_LAKEBASE_PROJECT` / `DEFAULT_LAKEBASE_DATABASE` in `scripts/deploy.config.sh`; `deploy.sh` resolves the segment (optional override: `LAKEBASE_DATABASE_RESOURCE_SEGMENT`). See §2a below. |
 | `psql` on PATH | Required by `scripts/bootstrap/lakebase-perms.sh` (`brew install libpq && brew link --force libpq` on macOS). |
 | UC grants for the app SP | The app runs as a service principal. See [§3 Unity Catalog Permissions for the Service Principal](#3-unity-catalog-permissions-for-the-service-principal) for the exact grants required on the registry catalog/schema, the registry volume, and your source tables. |
 | Lakebase grants for the app SP | `CAN_USE` on the Lakebase instance + `USAGE/DML` on the registry / graph / sync schemas. Bootstrap with `scripts/bootstrap/lakebase-perms.sh` (`make bootstrap-lakebase`) — `scripts/deploy.sh` runs it automatically on the `dev-lakebase` target. |
@@ -416,15 +416,16 @@ Deployment uses **Databricks Asset Bundles** to deploy both the main app and the
 # Create the project (once per workspace):
 ./scripts/bootstrap/setup-lakebase.sh --name ontobricks-demo --capacity CU_2
 
-# The script prints the db-… resource id at the end — copy it into
-# deploy.config.sh > DEFAULT_LAKEBASE_DATABASE_RESOURCE_SEGMENT.
+# The script prints the db-… resource id at the end. Set
+# DEFAULT_LAKEBASE_PROJECT / DEFAULT_LAKEBASE_DATABASE in deploy.config.sh;
+# deploy.sh resolves the segment (optional: LAKEBASE_DATABASE_RESOURCE_SEGMENT).
 ```
 
 The script:
 1. Creates the instance via `POST /api/2.0/database/instances` (synced-tables-compatible).
 2. Waits for `AVAILABLE`.
 3. Creates the Postgres database (`ontobricks_demo` by default).
-4. Prints the `db-…` segment needed for `deploy.config.sh`.
+4. Prints the `db-…` segment (informational — usually auto-resolved at deploy).
 
 **Options:**
 
@@ -469,8 +470,9 @@ Edit the workspace-specific defaults in `scripts/deploy.config.sh`:
 | `DEFAULT_REGISTRY_CATALOG` / `_SCHEMA` / `_VOLUME` | Bundle `volume` resource (`uc_securable: <cat>.<schema>.<volume>`) | UC namespace that hosts the binary-artefact volume + the triplestore VIEW. |
 | `DEFAULT_LAKEBASE_PROJECT` | `databricks.yml > var.lakebase_project` | Autoscaling **project id** (final segment of `projects/<id>`). |
 | `DEFAULT_LAKEBASE_BRANCH` | `databricks.yml > var.lakebase_branch` | Branch id (e.g. `production`). |
-| `DEFAULT_LAKEBASE_DATABASE_RESOURCE_SEGMENT` | `databricks.yml > var.lakebase_database_resource_segment` | **`db-…` resource id** from the Postgres API `name` field — **not** `datname` / `status.postgres_database`. Resolve with `databricks postgres list-databases "projects/<project>/branches/<branch>" -o json`. |
-| `DEFAULT_LAKEBASE_REGISTRY_SCHEMA` | `databricks.yml > var.lakebase_registry_schema` + `LAKEBASE_SCHEMA` at runtime | Postgres schema for the registry (e.g. `ontobricks_registry`). |
+| `DEFAULT_LAKEBASE_DATABASE` | Used by `deploy.sh` to resolve `var.lakebase_database_resource_segment` | Postgres **datname** (`status.postgres_database` from `list-databases`). Do **not** paste the `db-…` id here. |
+| `LAKEBASE_DATABASE_RESOURCE_SEGMENT` | `databricks.yml > var.lakebase_database_resource_segment` | Optional env override for the **`db-…` resource id**. When unset, `deploy.sh` resolves it from `DEFAULT_LAKEBASE_DATABASE` via the Postgres API. |
+| `DEFAULT_LAKEBASE_SCHEMA` | `databricks.yml > var.lakebase_registry_schema` + `LAKEBASE_SCHEMA` at runtime | Postgres schema for the registry (e.g. `ontobricks_registry`). |
 | `DEFAULT_APP_TRIPLESTORE_TABLE` | `app.yaml > DATABRICKS_TRIPLESTORE_TABLE` | Fully-qualified `catalog.schema.table` fallback for MCP/session-less paths. |
 | `DEFAULT_APP_MLFLOW_TRACKING_URI` | `app.yaml > MLFLOW_TRACKING_URI` | `databricks` (persists traces to the workspace) or empty for local-only. |
 
@@ -512,15 +514,29 @@ deploy script. The variables are:
 > `databricks_postgres` as `datname` with the same schema name inside
 > it — use `list-databases` to see which `db-…` row matches your bind.
 
-Update the `permissions` section in `databricks.yml` to grant `CAN_MANAGE`
-to the deploying user:
+Update **each app's** `permissions` block in `databricks.yml`
+(`resources.apps.<app>.permissions` — **not** the top-level bundle
+`permissions:`, which only allows `CAN_MANAGE` / `CAN_VIEW` / `CAN_RUN`
+and rejects `CAN_USE`). The sandbox already grants the deploying user
+`CAN_MANAGE` and the `users` group `CAN_USE` via
+`${workspace.current_user.userName}`; adjust only if you need a different ACL:
 
 ```yaml
-permissions:
-  - level: CAN_MANAGE
-    user_name: <your-email>
-  - level: CAN_USE
-    group_name: users
+resources:
+  apps:
+    ontobricks_dev_app:
+      # … name / source_code_path / resources …
+      permissions:
+        - level: CAN_MANAGE
+          user_name: ${workspace.current_user.userName}
+        - level: CAN_USE
+          group_name: users
+    mcp_ontobricks_app:
+      permissions:
+        - level: CAN_MANAGE
+          user_name: ${workspace.current_user.userName}
+        - level: CAN_USE
+          group_name: users
 ```
 
 > **MCP `ONTOBRICKS_URL`.** `src/mcp-server/app.yaml` still holds the
@@ -1031,7 +1047,8 @@ databricks current-user me
 # Create the project via the correct API (synced-tables-compatible):
 ./scripts/bootstrap/setup-lakebase.sh --name ontobricks-demo --capacity CU_2
 
-# Copy the printed db-… segment into deploy.config.sh (DEFAULT_LAKEBASE_DATABASE_RESOURCE_SEGMENT)
+# Copy DEFAULT_LAKEBASE_PROJECT / DEFAULT_LAKEBASE_DATABASE into deploy.config.sh
+# (deploy.sh resolves the db-… segment; optional: LAKEBASE_DATABASE_RESOURCE_SEGMENT)
 ```
 
 ### 5.2 — Prepare Unity Catalog resources
@@ -1064,8 +1081,10 @@ DEFAULT_REGISTRY_VOLUME="registry"
 
 DEFAULT_LAKEBASE_PROJECT="<lakebase-project-id>"
 DEFAULT_LAKEBASE_BRANCH="production"
-DEFAULT_LAKEBASE_DATABASE_RESOURCE_SEGMENT="<db-… from list-databases>"
-DEFAULT_LAKEBASE_REGISTRY_SCHEMA="ontobricks_registry"
+DEFAULT_LAKEBASE_DATABASE="<postgres-datname>"
+# Optional override — normally resolved by deploy.sh from DEFAULT_LAKEBASE_DATABASE:
+# LAKEBASE_DATABASE_RESOURCE_SEGMENT="<db-… from list-databases>"
+DEFAULT_LAKEBASE_SCHEMA="ontobricks_registry"
 
 DEFAULT_APP_TRIPLESTORE_TABLE="<catalog>.<schema>.<triplestore_table>"
 ```
@@ -1075,8 +1094,10 @@ DEFAULT_APP_TRIPLESTORE_TABLE="<catalog>.<schema>.<triplestore_table>"
 `app.yaml` from the template.
 
 **`databricks.yml`** — only the structural bits change here.
-Update the `permissions:` section with the deploying user's email
-(the `variables:` defaults are overridden by `deploy.config.sh`).
+Confirm each app's `permissions:` block (under
+`resources.apps.*`, not top-level) lists the deploying user with
+`CAN_MANAGE` (defaults use `${workspace.current_user.userName}`).
+The `variables:` defaults are overridden by `deploy.config.sh`.
 
 **`src/mcp-server/app.yaml`** — update the main app URL after the
 first deploy:
@@ -1140,9 +1161,9 @@ databricks bundle run mcp_ontobricks_app -t dev-lakebase
         - DEFAULT_APP_NAME / DEFAULT_MCP_APP_NAME
         - DEFAULT_WAREHOUSE_ID
         - DEFAULT_REGISTRY_CATALOG / _SCHEMA / _VOLUME
-        - DEFAULT_LAKEBASE_PROJECT / _BRANCH / _DATABASE_RESOURCE_SEGMENT / _REGISTRY_SCHEMA
+        - DEFAULT_LAKEBASE_PROJECT / _BRANCH / _DATABASE / _SCHEMA
         - DEFAULT_APP_TRIPLESTORE_TABLE
-[ ] 6.  Update databricks.yml permissions (your email with CAN_MANAGE)
+[ ] 6.  Confirm databricks.yml app permissions under resources.apps.* (CAN_MANAGE for you, CAN_USE for users)
 [ ] 7.  make bundle-validate
 [ ] 8.  make deploy                # scripts/deploy.sh -t dev-lakebase
 [ ] 9.  Bind sql-warehouse, volume, postgres resources in the Apps UI
@@ -1459,7 +1480,7 @@ Use this checklist when deploying OntoBricks from scratch on any workspace:
         [ ] A catalog you can use (e.g., main or your personal catalog)
         [ ] A schema within that catalog (e.g., ontobricks)
         [ ] A Volume for the project registry (e.g., OntoBricksRegistry)
-[ ] 4.  Lakebase project created via `scripts/bootstrap/setup-lakebase.sh` (`db-…` id copied into `deploy.config.sh`)
+[ ] 4.  Lakebase project created via `scripts/bootstrap/setup-lakebase.sh` (`DEFAULT_LAKEBASE_PROJECT` / `DEFAULT_LAKEBASE_DATABASE` set in `deploy.config.sh`)
         (required since v0.4.0 — Provisioned tier is not supported).
         Resolve the db-… resource id:
           databricks postgres list-databases \
@@ -1469,10 +1490,10 @@ Use this checklist when deploying OntoBricks from scratch on any workspace:
         [ ] DEFAULT_APP_NAME / DEFAULT_MCP_APP_NAME
         [ ] DEFAULT_WAREHOUSE_ID
         [ ] DEFAULT_REGISTRY_CATALOG / _SCHEMA / _VOLUME
-        [ ] DEFAULT_LAKEBASE_PROJECT / _BRANCH / _DATABASE_RESOURCE_SEGMENT
-        [ ] DEFAULT_LAKEBASE_REGISTRY_SCHEMA (mirrored as LAKEBASE_SCHEMA in app.yaml)
+        [ ] DEFAULT_LAKEBASE_PROJECT / _BRANCH / _DATABASE
+        [ ] DEFAULT_LAKEBASE_SCHEMA (mirrored as LAKEBASE_SCHEMA in app.yaml)
         [ ] DEFAULT_APP_TRIPLESTORE_TABLE
-[ ] 7.  Update databricks.yml permissions (your email with CAN_MANAGE)
+[ ] 7.  Confirm databricks.yml app permissions under resources.apps.* (CAN_MANAGE for you, CAN_USE for users)
 [ ] 8.  Validate:  make bundle-validate
 [ ] 9.  Deploy:    make deploy                  # runs scripts/deploy.sh -t dev-lakebase
 [ ] 10. Verify bundle bound sql-warehouse / volume / postgres on both apps

--- a/documentation/deployment.md
+++ b/documentation/deployment.md
@@ -357,7 +357,7 @@ in the deployed app:
 
 - Pick the **Secret scope** and **Secret name** from the dropdowns in
   **Settings → Back end → Neo4j** (populated live via the Databricks Secrets
-  API).
+  API). Deploy does **not** create or bind that secret (Neo4j is optional).
 - The app's own identity (SP OAuth in Apps, PAT/CLI profile locally) needs
   `READ` on that scope — see
   `documentation/pr47-neo4j-demo/secret-configuration.md` for the one-time

--- a/documentation/lakebase-graphdb.md
+++ b/documentation/lakebase-graphdb.md
@@ -169,10 +169,14 @@ On success the chosen project/branch/database/schema are written into
 
 ### 3.2 — After the script
 
-Copy the printed `db-…` segment into `scripts/deploy.config.sh`:
+Set the project + Postgres datname in `scripts/deploy.config.sh`
+(`deploy.sh` resolves the `db-…` segment automatically):
 
 ```bash
-DEFAULT_LAKEBASE_DATABASE_RESOURCE_SEGMENT="db-xxxx-xxxxxxxxxx"
+DEFAULT_LAKEBASE_PROJECT="<project-name>"
+DEFAULT_LAKEBASE_DATABASE="<postgres-datname>"
+# Optional override:
+# LAKEBASE_DATABASE_RESOURCE_SEGMENT="db-xxxx-xxxxxxxxxx"
 ```
 
 You can also look it up at any time:
@@ -264,9 +268,9 @@ These drive the DAB deployment (edit before `make deploy`):
 |----------|-------------|
 | `DEFAULT_LAKEBASE_PROJECT` | Lakebase project name (final segment of `projects/<id>`) |
 | `DEFAULT_LAKEBASE_BRANCH` | Branch (e.g. `production`) |
-| `DEFAULT_LAKEBASE_DATABASE_RESOURCE_SEGMENT` | `db-…` resource id from `list-databases` |
-| `DEFAULT_LAKEBASE_REGISTRY_DATABASE` | Postgres datname the registry schema lives in |
-| `DEFAULT_LAKEBASE_REGISTRY_SCHEMA` | Postgres schema for the registry (mirrors `LAKEBASE_SCHEMA` in `app.yaml`) |
+| `DEFAULT_LAKEBASE_DATABASE` | Postgres datname the registry schema lives in |
+| `LAKEBASE_DATABASE_RESOURCE_SEGMENT` | Optional env override for the `db-…` id; when unset, `deploy.sh` resolves it from `DEFAULT_LAKEBASE_DATABASE` |
+| `DEFAULT_LAKEBASE_SCHEMA` | Postgres schema for the registry (mirrors `LAKEBASE_SCHEMA` in `app.yaml`) |
 
 > `deploy.config.sh` is **registry-scoped**. The graph DB schema/database
 > are configured in-app (`Settings → Graph DB` → `graph_engine_config`)
@@ -406,7 +410,7 @@ Provisions a Lakebase project via `POST /api/2.0/database/instances` (synced-tab
 ./scripts/bootstrap/setup-lakebase.sh --name my-project --profile prod-workspace
 ```
 
-**Outputs:** prints the `db-…` resource id that goes into `deploy.config.sh > DEFAULT_LAKEBASE_DATABASE_RESOURCE_SEGMENT`.
+**Outputs:** prints the `db-…` resource id (informational). Set `DEFAULT_LAKEBASE_PROJECT` / `DEFAULT_LAKEBASE_DATABASE` in `deploy.config.sh`; optional override `LAKEBASE_DATABASE_RESOURCE_SEGMENT`.
 
 ### `scripts/bootstrap/lakebase-perms.sh`
 
@@ -551,7 +555,7 @@ The Synced Tables API only accepts provisioned instance names.
 **Fix:**
 1. Delete the old project from the UI.
 2. Re-create it with `scripts/bootstrap/setup-lakebase.sh`.
-3. Update `DEFAULT_LAKEBASE_DATABASE_RESOURCE_SEGMENT` in `deploy.config.sh`.
+3. Update `DEFAULT_LAKEBASE_PROJECT` / `DEFAULT_LAKEBASE_DATABASE` in `deploy.config.sh` (optional: `LAKEBASE_DATABASE_RESOURCE_SEGMENT`).
 4. `make deploy`.
 
 If the name is reserved (`Instance name is not unique`), choose a different name —
@@ -655,9 +659,9 @@ and the project+branch pair. This means `lakebase_project` or
 `lakebase_database_resource_segment` is empty in `deploy.config.sh`.
 
 **Fix:**
-1. Run `databricks postgres list-databases "projects/<project>/branches/<branch>" -o json`.
-2. Copy the `name` field (looks like `db-xxxx-xxxxxxxxxx`) into
-   `DEFAULT_LAKEBASE_DATABASE_RESOURCE_SEGMENT` in `deploy.config.sh`.
+1. Confirm `DEFAULT_LAKEBASE_PROJECT` / `DEFAULT_LAKEBASE_DATABASE` in `deploy.config.sh`.
+2. If auto-resolve fails, set `LAKEBASE_DATABASE_RESOURCE_SEGMENT=db-xxxx-xxxxxxxxxx`
+   (from `databricks postgres list-databases "projects/<project>/branches/<branch>" -o json`).
 3. `make deploy`.
 
 ---
@@ -710,9 +714,9 @@ instead of `window.confirm()`. If you see this on an older deployment,
 ```
 [ ] 1. Create Lakebase project:
         ./scripts/bootstrap/setup-lakebase.sh --name <name> --capacity CU_2
-[ ] 2. Copy the printed db-… id into deploy.config.sh:
-        DEFAULT_LAKEBASE_DATABASE_RESOURCE_SEGMENT="db-xxxx-xxxxxxxxxx"
-[ ] 3. Set DEFAULT_LAKEBASE_PROJECT and DEFAULT_LAKEBASE_BRANCH in deploy.config.sh
+[ ] 2. Set DEFAULT_LAKEBASE_PROJECT / DEFAULT_LAKEBASE_DATABASE in deploy.config.sh
+        (optional override: LAKEBASE_DATABASE_RESOURCE_SEGMENT="db-xxxx-xxxxxxxxxx")
+[ ] 3. Set DEFAULT_LAKEBASE_BRANCH (and DEFAULT_LAKEBASE_SCHEMA if needed) in deploy.config.sh
 [ ] 4. make deploy
 [ ] 5. Bind resources in Databricks Apps UI (sql-warehouse, volume, postgres)
 [ ] 6. Open app → Settings → Registry → Initialize

--- a/documentation/pr47-neo4j-demo/secret-configuration.md
+++ b/documentation/pr47-neo4j-demo/secret-configuration.md
@@ -46,9 +46,25 @@ Open the OntoBricks app: **Settings → Back end → Neo4j**.
 
 Local dev goes through the exact same path as the deployed app — no plain-text fallback. Your local Databricks auth (`DATABRICKS_TOKEN`, or a `databricks auth login` CLI profile) is used to call the Secrets API, so make sure that identity has `READ` on the chosen scope (step 2 above).
 
+## Deploy does **not** bind Neo4j secrets
+
+`./scripts/deploy.sh` / DAB do **not** attach a workspace secret to the app.
+Neo4j is optional; requiring `ontobricks-secrets` / `neo4j-password` at
+`terraform apply` blocked first-time deploys that never use Neo4j (see
+[GH #136](https://github.com/databrickslabs/ontobricks/issues/136)).
+Create the secret only when you enable Neo4j (steps above), then pick
+scope/key in Settings after the app is running.
+
 ## Legacy: `NEO4J_PASSWORD` env var / Apps secret resource
 
-Deployments that already bind the `neo4j-password` Apps secret resource (`app.yaml` `valueFrom`) keep working unmodified — the backend still supports `auth_method: "basic"` and prioritizes the `NEO4J_PASSWORD` env var when it's set. This path is **not exposed in the Settings UI anymore**; it only remains for existing configs that haven't been migrated. To migrate, open Settings → Neo4j and Save once with a scope/key picked — this overwrites `auth_method` to `"databricks_secret"`.
+`app.yaml` still declares an **unbound** `neo4j-password` Apps secret resource
+and `NEO4J_PASSWORD` env var. Deployments that already bind that resource in
+the Apps UI keep working unmodified — the backend still supports
+`auth_method: "basic"` and prioritizes the `NEO4J_PASSWORD` env var when it's
+set. This path is **not exposed in the Settings UI anymore**; it only remains
+for existing configs that haven't been migrated. To migrate, open Settings →
+Neo4j and Save once with a scope/key picked — this overwrites `auth_method` to
+`"databricks_secret"`.
 
 ## Troubleshooting
 

--- a/documentation/user-guide.md
+++ b/documentation/user-guide.md
@@ -637,7 +637,7 @@ After an analysis, a **Data Model Health** card shows entity types that may not 
 | **Entity Type** | Class URI local name |
 | **Instances** | Count of instances in the graph |
 | **Rel. Predicates** | Distinct entity-to-entity relationship predicates (excludes `rdf:type`, `rdfs:label`, and literal attributes; counts both incoming and outgoing relationships) |
-| **Temporal** | Whether any predicate name contains a temporal keyword (e.g. `date`, `timestamp`) |
+| **Temporal** | Whether any camelCase/snake_case token of a predicate name is a temporal keyword (e.g. `date`, `timestamp`, `at`) |
 
 An entity type is flagged as **flat / time-series** when:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ontobricks"
-version = "0.7.0"
+version = "0.7.1"
 description = "Ontology Management Tool for Databricks"
 requires-python = ">=3.10"
 dependencies = [

--- a/releases/ReleaseNotes_V0.7.1.md
+++ b/releases/ReleaseNotes_V0.7.1.md
@@ -1,0 +1,154 @@
+# OntoBricks — Release Notes V0.7.1
+
+**Release window:** August, 2026
+**Type:** Patch release (v0.7.0 → v0.7.1)
+**Test status:** all changes shipped with the suite green (4798 passed, 276 skipped, 5 deselected, 1 xfailed).
+
+---
+
+## Summary
+
+v0.7.1 is a focused **deploy / first-time onboarding** patch on top of v0.7.0.
+It clears five GitHub issues that blocked or confused new Databricks Apps
+installs: broken bootstrap script paths after the `scripts/bootstrap/` reorg,
+incorrect DAB app-permission nesting, stale Lakebase segment docs, a forced
+Neo4j secret binding that most workspaces do not have, and Registry → Initialize
+looking up the wrong MCP app name on instance-suffixed deploys.
+
+No product-feature changes. No schema migrations. No breaking API changes.
+
+---
+
+## Highlights
+
+- **Bootstrap scripts find the repo root again ([#133](https://github.com/databrickslabs/ontobricks/issues/133))** —
+  `setup-lakebase.sh`, `app-permissions.sh`, and `lakebase-perms.sh` `cd` to the
+  repository root after the `scripts/bootstrap/` move so `deploy.config.sh` and
+  sibling helpers resolve correctly.
+- **DAB app permissions nesting ([#134](https://github.com/databrickslabs/ontobricks/issues/134))** —
+  `CAN_MANAGE` / `CAN_USE` for both apps live under `resources.apps.*` in
+  `databricks.yml` (bundle top-level permissions are invalid / ignored).
+- **Lakebase deploy-config docs ([#135](https://github.com/databrickslabs/ontobricks/issues/135))** —
+  documentation matches auto-resolved `LAKEBASE_DATABASE_RESOURCE_SEGMENT` and
+  the current `DEFAULT_LAKEBASE_DATABASE` / `_SCHEMA` knobs.
+- **Neo4j secret no longer required at deploy ([#136](https://github.com/databrickslabs/ontobricks/issues/136))** —
+  DAB no longer binds `neo4j-password` / `ontobricks-secrets`; Neo4j stays
+  optional via Settings → Neo4j (Secrets API).
+- **MCP SP + UC grants on first Initialize ([#137](https://github.com/databrickslabs/ontobricks/issues/137))** —
+  registry/graph grants derive `mcp-{APP_NAME}` (e.g. `mcp-ontobricks-07x`);
+  `MCP_APP_NAME` is injected into `app.yaml`; UC catalog `ALL_PRIVILEGES` runs
+  in `lakebase-perms.sh` **before** the schema-existence guard so first deploy
+  still applies them.
+
+---
+
+## Bug Fixes
+
+### Bootstrap path after `scripts/bootstrap/` reorg ([#133](https://github.com/databrickslabs/ontobricks/issues/133))
+
+After bootstrap scripts moved under `scripts/bootstrap/`, relative `cd` /
+`source` paths no longer reached the repo root. First-time Lakebase setup and
+permission grants failed or ran against the wrong working directory.
+
+- `scripts/bootstrap/setup-lakebase.sh`
+- `scripts/bootstrap/app-permissions.sh`
+- `scripts/bootstrap/lakebase-perms.sh`
+
+### DAB app-level permissions nesting ([#134](https://github.com/databrickslabs/ontobricks/issues/134))
+
+App ACL entries must be nested under each app resource. Top-level bundle
+`permissions` do not apply the intended `CAN_USE` / `CAN_MANAGE` grants.
+
+- `databricks.yml` — nest permissions under `resources.apps.ontobricks_dev_app`
+  and `resources.apps.mcp_ontobricks_app`
+- `documentation/deployment.md` — document the correct nesting
+
+### Stale Lakebase segment / deploy.config variable names ([#135](https://github.com/databrickslabs/ontobricks/issues/135))
+
+Docs still described a manually set `DEFAULT_LAKEBASE_DATABASE_RESOURCE_SEGMENT`
+after deploy started auto-resolving the `db-…` segment from the Postgres API.
+
+- `documentation/deployment.md`
+- `documentation/lakebase-graphdb.md`
+- `scripts/bootstrap/setup-lakebase.sh` help text
+
+### Neo4j secret binding aborted first deploy ([#136](https://github.com/databrickslabs/ontobricks/issues/136))
+
+`./scripts/deploy.sh` failed when the workspace lacked
+`ontobricks-secrets` / `neo4j-password`, even though Neo4j is optional and
+configured in-app via the Secrets API.
+
+- `databricks.yml` — remove `neo4j_secret_scope` and the `neo4j-password` overlay
+- `scripts/_internal/_ensure-instance-target.sh` — stop emitting the secret for
+  generated `dev-lakebase-<id>` targets
+- `scripts/deploy.config.sh` / `scripts/deploy.sh` — drop the secret-scope
+  preflight / `--var`
+- `app.yaml.template` — clarify the unbound resource is legacy-only
+
+### MCP companion SP skipped on instance-suffixed apps ([#137](https://github.com/databrickslabs/ontobricks/issues/137))
+
+With `INSTANCE_ID=07x`, deploy creates `mcp-ontobricks-07x`, but Registry →
+Initialize looked up bare `mcp-ontobricks` and skipped MCP grants. Separately,
+UC catalog grants in `lakebase-perms.sh` ran only after the schema guard, so a
+first deploy (schema not yet created) never granted catalog `ALL_PRIVILEGES`;
+in-app re-grants as the app SP then warned about missing `MANAGE`.
+
+- `src/back/core/databricks/lakebase/grants.py` — `resolve_mcp_app_name`
+  (`mcp-{APP_NAME}`); clearer CAN_USE / UC warning text
+- `src/back/objects/domain/SettingsService.py` — registry + graph provision use
+  the derived MCP name
+- `app.yaml.template` — inject `MCP_APP_NAME` at deploy time
+- `scripts/bootstrap/lakebase-perms.sh` — UC catalog grants before schema guard
+- `src/front/templates/settings.html` — blank MCP field derives `mcp-{main app}`
+
+---
+
+## Documentation
+
+- Deployment guide: bootstrap paths, app ACL nesting, Lakebase variable names,
+  Neo4j-optional deploy, MCP naming (`mcp-${APP_NAME}`), first-deploy UC grant
+  timing, and why elevating the app SP to `CAN_MANAGE` is the wrong fix for
+  Initialize warnings.
+- Lakebase Graph DB guide aligned with auto-resolved database resource segment.
+- Neo4j secret-configuration note: DAB does not bind Neo4j secrets.
+
+---
+
+## Upgrade notes
+
+- **From 0.7.0:** pull `0.7.1` and re-run `./scripts/deploy.sh` (or `make deploy`).
+  No registry or graph rebuild required for this patch alone.
+- **Existing instance-suffixed apps (`ontobricks-07x` / `mcp-ontobricks-07x`):**
+  after deploy, open **Settings → Registry → Repair permissions** (or Initialize
+  again) so MCP grants target `mcp-ontobricks-07x`. If UC catalog privileges are
+  still missing, re-run as a workspace admin:
+
+  ```bash
+  source scripts/deploy.config.sh
+  scripts/bootstrap/lakebase-perms.sh \
+    -i "$LAKEBASE_PROJECT" -b "$LAKEBASE_BRANCH" \
+    -d "$LAKEBASE_DATABASE" -s "$LAKEBASE_SCHEMA" \
+    -c "$REGISTRY_CATALOG" \
+    -a "$APP_NAME" -a "$MCP_APP_NAME"
+  ```
+
+- **Do not** elevate the app service principal to Lakebase `CAN_MANAGE` or
+  catalog `MANAGE` just to silence Initialize warnings — grant `ALL PRIVILEGES`
+  **to** the SP from an admin principal via the bootstrap script (or SQL) instead.
+- **Neo4j:** if you previously relied on a DAB-bound `neo4j-password` resource,
+  configure the connection under **Settings → Neo4j** with a Databricks secret
+  scope/key (unchanged product path).
+- **New deploys:** use `./scripts/deploy.sh` end-to-end; bootstrap scripts now
+  resolve correctly from `scripts/bootstrap/`.
+
+---
+
+## Issues closed
+
+| Issue | Title |
+|-------|--------|
+| [#133](https://github.com/databrickslabs/ontobricks/issues/133) | Lakebase setup / bootstrap path after scripts reorg |
+| [#134](https://github.com/databrickslabs/ontobricks/issues/134) | DAB app permissions nesting |
+| [#135](https://github.com/databrickslabs/ontobricks/issues/135) | Stale Lakebase deploy.config variable docs |
+| [#136](https://github.com/databrickslabs/ontobricks/issues/136) | Deploy requires missing Neo4j secret |
+| [#137](https://github.com/databrickslabs/ontobricks/issues/137) | MCP SP unresolved / UC grants after registry init |

--- a/scripts/_internal/_ensure-instance-target.sh
+++ b/scripts/_internal/_ensure-instance-target.sh
@@ -52,12 +52,8 @@ targets:
                 branch: projects/\${var.lakebase_project}/branches/\${var.lakebase_branch}
                 database: projects/\${var.lakebase_project}/branches/\${var.lakebase_branch}/databases/\${var.lakebase_database_resource_segment}
                 permission: "CAN_CONNECT_AND_CREATE"
-            - name: neo4j-password
-              description: "Databricks Apps secret holding the Neo4j Bolt password"
-              secret:
-                scope: \${var.neo4j_secret_scope}
-                key: neo4j-password
-                permission: READ
+            # Neo4j secrets are NOT bound at deploy time (optional engine;
+            # configure in Settings post-deploy). See GH #136.
         mcp_ontobricks_app:
           resources:
             - name: postgres

--- a/scripts/bootstrap/app-permissions.sh
+++ b/scripts/bootstrap/app-permissions.sh
@@ -23,7 +23,8 @@ set -euo pipefail
 #   - The apps already exist (run `make deploy` first)
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-cd "$SCRIPT_DIR/.."
+# scripts/bootstrap/ → scripts/ → repo root (needed for scripts/deploy.config.sh — #133).
+cd "$SCRIPT_DIR/../.."
 
 # Default sandbox app pair. Override via env (e.g.
 # `APP_NAME=ontobricks-040 scripts/bootstrap/app-permissions.sh`) to

--- a/scripts/bootstrap/lakebase-perms.sh
+++ b/scripts/bootstrap/lakebase-perms.sh
@@ -13,13 +13,16 @@ set -euo pipefail
 # principal client id, and grants it the privileges OntoBricks needs:
 #
 #   - CAN_USE on the Lakebase project (control-plane, both API endpoints)
+#   - (when -c/--catalog) ALL PRIVILEGES on the UC catalog (control-plane;
+#     applied before the schema exists so a first deploy still grants it —
+#     Initialize cannot self-serve this because the app SP lacks MANAGE)
 #   - USAGE + CREATE on the Postgres schema (data-plane)
 #   - SELECT/INSERT/UPDATE/DELETE on every existing table
 #   - USAGE/SELECT/UPDATE on every existing sequence (bigserial PKs)
 #   - The same set as ALTER DEFAULT PRIVILEGES so future tables inherit
-#   - (managed_synced only) ALL PRIVILEGES on the UC catalog so the SP
-#     can read back synced tables it created or that were pre-created by
-#     another principal.  Pass -c/--catalog to enable this grant.
+#
+# Pass -c/--catalog (or UC_CATALOG) to enable the UC catalog grant — required
+# for managed_synced mode so the SP can read back synced tables.
 #
 # Idempotent — re-running is a no-op for objects that already carry the
 # privileges.
@@ -249,6 +252,24 @@ print(d.get("service_principal_client_id") or "")' 2>/dev/null || true)"
         echo "  [$app] ✗ Both CAN_USE grant attempts failed."
         FAILED=$((FAILED+1))
     fi
+
+    # ── UC catalog ALL_PRIVILEGES (control-plane — no schema required) ──
+    # Must run BEFORE the schema guard. On a first deploy the registry
+    # schema does not exist yet, so the script used to exit early and
+    # never grant UC privileges; Initialize then tried (and failed) as
+    # the app SP which lacks MANAGE on the catalog (#137).
+    if [[ -n "${UC_CATALOG:-}" ]]; then
+        echo "  [$app] granting ALL PRIVILEGES on UC catalog '${UC_CATALOG}'..."
+        if databricks grants update CATALOG "${UC_CATALOG}" \
+            --json "{\"changes\": [{\"principal\": \"${sp_id}\", \"add\": [\"ALL_PRIVILEGES\"]}]}" \
+            >/dev/null 2>&1; then
+            echo "  [$app] ✓ UC ALL_PRIVILEGES granted on catalog '${UC_CATALOG}'"
+        else
+            echo "  [$app] ⚠ UC catalog grant failed (you may lack MANAGE on catalog '${UC_CATALOG}')"
+            echo "          Run manually: databricks grants update CATALOG ${UC_CATALOG} \\"
+            echo "            --json '{\"changes\":[{\"principal\":\"${sp_id}\",\"add\":[\"ALL_PRIVILEGES\"]}]}'"
+        fi
+    fi
 done
 
 # ── Step 2: Postgres schema grants (requires the schema to exist) ────────────
@@ -265,8 +286,8 @@ if ! psql "$PGCONN" -tAc "SELECT 1 FROM information_schema.schemata WHERE schema
     fi
     echo "ERROR: Schema '${SCHEMA}' does not exist in database '${DATABASE}'." >&2
     echo "       Initialise the registry from the OntoBricks Settings UI first." >&2
-    echo "       CAN_USE grants above were applied — re-run after initialisation" >&2
-    echo "       to apply the Postgres schema grants." >&2
+    echo "       CAN_USE / UC catalog grants above were applied — re-run after" >&2
+    echo "       initialisation to apply the Postgres schema grants." >&2
     exit 1
 fi
 
@@ -586,29 +607,6 @@ SQL
     else
         echo "  [$app] ✗ verify failed (USAGE=$has_usage, SELECT=${first_table:-<no tables>}=$has_select)"
         FAILED=$((FAILED+1))
-    fi
-
-    # ── 3. Unity Catalog: ALL PRIVILEGES on catalog (managed_synced only) ───
-    # The Lakebase synced-table API (GET /api/2.0/database/synced_tables/{fqn})
-    # returns 404 when the caller lacks SELECT on the resulting UC table — even
-    # when it created the table.  This happens when:
-    #   a) The table was created by a different principal (local dev run) and
-    #      the SP is not the owner.
-    #   b) The SP has UC CAN_USE but the catalog-level SELECT has not been
-    #      explicitly applied.
-    # Granting ALL PRIVILEGES on the catalog covers both cases and is idempotent.
-    # Only done when -c/--catalog (or UC_CATALOG env var) is provided.
-    if [[ -n "${UC_CATALOG:-}" ]]; then
-        echo "  [$app] granting ALL PRIVILEGES on UC catalog '${UC_CATALOG}'..."
-        if databricks grants update CATALOG "${UC_CATALOG}" \
-            --json "{\"changes\": [{\"principal\": \"${sp_id}\", \"add\": [\"ALL_PRIVILEGES\"]}]}" \
-            >/dev/null 2>&1; then
-            echo "  [$app] ✓ UC ALL_PRIVILEGES granted on catalog '${UC_CATALOG}'"
-        else
-            echo "  [$app] ⚠ UC catalog grant failed (you may lack MANAGE on catalog '${UC_CATALOG}')"
-            echo "          Run manually: databricks grants update CATALOG ${UC_CATALOG} \\"
-            echo "            --json '{\"changes\":[{\"principal\":\"${sp_id}\",\"add\":[\"ALL_PRIVILEGES\"]}]}'"
-        fi
     fi
 done
 

--- a/scripts/bootstrap/lakebase-perms.sh
+++ b/scripts/bootstrap/lakebase-perms.sh
@@ -63,7 +63,8 @@ set -euo pipefail
 #   - You own the schema (or otherwise have GRANT OPTION on it).
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-cd "$SCRIPT_DIR/.."
+# scripts/bootstrap/ → scripts/ → repo root (#133).
+cd "$SCRIPT_DIR/../.."
 
 # _lakebase-diag.sh lives in scripts/_internal/ (moved there by the scripts/
 # reorg, commit 2c6ef76); this script is in scripts/bootstrap/, so reference

--- a/scripts/bootstrap/setup-lakebase.sh
+++ b/scripts/bootstrap/setup-lakebase.sh
@@ -18,7 +18,7 @@
 #   which calls the NEW API) to provision your Lakebase project.
 #
 # Usage:
-#   ./scripts/setup-lakebase.sh [OPTIONS]
+#   ./scripts/bootstrap/setup-lakebase.sh [OPTIONS]
 #
 # Options:
 #   --name      NAME       Project name (default: ontobricks-demo)
@@ -31,8 +31,9 @@
 #   --dry-run              Print what would be done without doing it
 #
 # After this script succeeds:
-#   1. Update DEFAULT_LAKEBASE_DATABASE_RESOURCE_SEGMENT in
-#      scripts/deploy.config.sh with the printed db-... id.
+#   1. Update DEFAULT_LAKEBASE_PROJECT / DEFAULT_LAKEBASE_DATABASE in
+#      scripts/deploy.config.sh (datname). deploy.sh resolves the db-…
+#      segment automatically; optional override: LAKEBASE_DATABASE_RESOURCE_SEGMENT.
 #   2. Rebind the postgres resource in the Databricks Apps UI if needed.
 #   3. Run: make deploy
 #   4. Run: make bootstrap-lakebase
@@ -40,7 +41,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-cd "$SCRIPT_DIR/.."
+# scripts/bootstrap/ → scripts/ → repo root (one level was wrong after the reorg — #133).
+cd "$SCRIPT_DIR/../.."
 
 # Preflight CLI auth + tooling before any API calls.
 chmod +x scripts/_internal/check-deploy-prerequisites.sh
@@ -269,7 +271,8 @@ echo "║  NEXT STEPS:                                                 ║"
 echo "║                                                              ║"
 echo "║  1. Update scripts/deploy.config.sh:                        ║"
 echo "║     DEFAULT_LAKEBASE_PROJECT=\"$NAME\""
-echo "║     DEFAULT_LAKEBASE_DATABASE_RESOURCE_SEGMENT=\"${DB_SEGMENT:-<db-segment>}\""
+echo "║     DEFAULT_LAKEBASE_DATABASE=\"$DATABASE\""
+echo "║     # optional: LAKEBASE_DATABASE_RESOURCE_SEGMENT=\"${DB_SEGMENT:-db-…}\""
 echo "║                                                              ║"
 echo "║  2. In Databricks Apps UI: rebind the postgres resource      ║"
 echo "║     to the new project endpoint (if the host changed).       ║"
@@ -281,7 +284,9 @@ echo "╚═══════════════════════�
 echo ""
 
 if [[ -n "$DB_SEGMENT" ]]; then
-  echo "Copy-paste for deploy.config.sh:"
-  echo "  DEFAULT_LAKEBASE_DATABASE_RESOURCE_SEGMENT=\"$DB_SEGMENT\""
+  echo "Copy-paste for deploy.config.sh (datname + optional segment override):"
+  echo "  DEFAULT_LAKEBASE_PROJECT=\"$NAME\""
+  echo "  DEFAULT_LAKEBASE_DATABASE=\"$DATABASE\""
+  echo "  # LAKEBASE_DATABASE_RESOURCE_SEGMENT=\"$DB_SEGMENT\"  # optional; deploy.sh auto-resolves"
   echo ""
 fi

--- a/scripts/deploy.config.sh
+++ b/scripts/deploy.config.sh
@@ -60,12 +60,6 @@ DEFAULT_REGISTRY_CATALOG="benoit_cayla"
 DEFAULT_REGISTRY_SCHEMA="ontobricks_demo"
 DEFAULT_REGISTRY_VOLUME="registry"
 
-# Workspace secret scope holding ``neo4j-password``, bound to the app on deploy.
-# Must be an existing scope (`databricks secrets list-scopes`) — a missing scope
-# fails `terraform apply` on the app resource, and because an app rename is a
-# destroy-then-create, that failure can leave you with no app at all.
-DEFAULT_NEO4J_SECRET_SCOPE="ontobricks-secrets"
-
 # Lakebase Autoscaling project + branch
 DEFAULT_LAKEBASE_PROJECT="ontobricks-demo2"
 DEFAULT_LAKEBASE_BRANCH="production"
@@ -129,7 +123,6 @@ export REGISTRY_CATALOG="${REGISTRY_CATALOG:-$DEFAULT_REGISTRY_CATALOG}"
 # the routine deploy still always uses DEFAULT_REGISTRY_SCHEMA.
 export REGISTRY_SCHEMA="${REGISTRY_SCHEMA:-$DEFAULT_REGISTRY_SCHEMA}"
 export REGISTRY_VOLUME="${REGISTRY_VOLUME:-$DEFAULT_REGISTRY_VOLUME}"
-export NEO4J_SECRET_SCOPE="${NEO4J_SECRET_SCOPE:-$DEFAULT_NEO4J_SECRET_SCOPE}"
 
 # Lakebase project / branch.
 export LAKEBASE_PROJECT="${LAKEBASE_PROJECT:-$DEFAULT_LAKEBASE_PROJECT}"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -163,7 +163,6 @@ _dab_var_overrides=(
     "--var=registry_catalog=${REGISTRY_CATALOG}"
     "--var=registry_schema=${REGISTRY_SCHEMA}"
     "--var=registry_volume=${REGISTRY_VOLUME}"
-    "--var=neo4j_secret_scope=${NEO4J_SECRET_SCOPE}"
     "--var=lakebase_project=${LAKEBASE_PROJECT}"
     "--var=lakebase_branch=${LAKEBASE_BRANCH}"
     "--var=lakebase_database_resource_segment=${LAKEBASE_DATABASE_RESOURCE_SEGMENT}"
@@ -391,24 +390,8 @@ else
         || die "aborted before any change was made — nothing was destroyed."
 fi
 
-# Only the target that actually binds the secret should be held to it.
-_target_binds_neo4j_secret() {
-    awk -v want="  ${TARGET}:" '
-        $0 == want { inblock = 1; next }
-        inblock && /^  [a-zA-Z]/ { inblock = 0 }
-        inblock && /key: neo4j-password/ { found = 1 }
-        END { exit found ? 0 : 1 }
-    ' databricks.yml
-}
-if _target_binds_neo4j_secret; then
-    if ! _preflight_check_secret_scope "${NEO4J_SECRET_SCOPE:-}" "neo4j-password"; then
-        if $DRY_RUN; then
-            warn "secret binding preflight failed — the app resource would fail to deploy."
-        else
-            die "the app binds a secret that cannot be read — fix it above, or remove the neo4j-password overlay from the '${TARGET}' target in databricks.yml."
-        fi
-    fi
-fi
+# Neo4j Apps secret is no longer bound by DAB (optional engine; Settings
+# resolves the password via the Secrets API). No secret-scope preflight.
 
 # ── 3. Render app.yaml from template ────────────────────────────────
 begin_step "Render app.yaml"

--- a/src/back/core/databricks/lakebase/__init__.py
+++ b/src/back/core/databricks/lakebase/__init__.py
@@ -11,6 +11,7 @@ from back.core.databricks.lakebase.grants import (  # noqa: F401
     grant_schema_privileges,
     grant_uc_catalog,
     resolve_app_service_principals,
+    resolve_mcp_app_name,
 )
 from back.core.databricks.lakebase.LakebaseAuth import (  # noqa: F401
     BranchLakebaseAuth,
@@ -38,6 +39,7 @@ __all__ = [
     "get_lakebase_auth",
     # grants
     "resolve_app_service_principals",
+    "resolve_mcp_app_name",
     "grant_can_use_on_project",
     "grant_schema_privileges",
     "grant_uc_catalog",

--- a/src/back/core/databricks/lakebase/grants.py
+++ b/src/back/core/databricks/lakebase/grants.py
@@ -25,11 +25,50 @@ human-readable strings the caller aggregates into its task/route result.
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Tuple
+import os
+from typing import Any, Dict, List, Optional, Tuple
 
 from back.core.logging import get_logger
 
 logger = get_logger(__name__)
+
+
+def resolve_mcp_app_name(
+    app_name: str = "",
+    *,
+    explicit: str = "",
+    env: Optional[Dict[str, str]] = None,
+) -> str:
+    """Resolve the MCP companion Databricks App name.
+
+    Mirrors ``scripts/deploy.config.sh``::
+
+        DEFAULT_MCP_APP_NAME="mcp-${DEFAULT_APP_NAME}"
+
+    Precedence:
+
+    1. ``explicit`` (UI / caller override)
+    2. ``MCP_APP_NAME`` env (injected into ``app.yaml`` at deploy time)
+    3. ``mcp-{app_name}`` derived from the running main app
+    4. bare ``mcp-ontobricks`` only when no main app name is known
+
+    Without (3), instance-suffixed deploys (``ontobricks-07x`` →
+    ``mcp-ontobricks-07x``) look up the wrong app and skip MCP grants
+    (GitHub #137).
+    """
+    override = (explicit or "").strip()
+    if override:
+        return override
+    environ = env if env is not None else os.environ
+    from_env = (environ.get("MCP_APP_NAME") or "").strip()
+    if from_env:
+        return from_env
+    main = (app_name or "").strip()
+    if not main:
+        return "mcp-ontobricks"
+    if main.startswith("mcp-"):
+        return main
+    return f"mcp-{main}"
 
 
 def resolve_app_service_principals(
@@ -70,6 +109,12 @@ def grant_can_use_on_project(
     Tries both the Autoscaling (``database-projects``) and Provisioned
     (``database-instances``) permission securables; success on either is
     enough. Best-effort — a failure on both becomes a warning.
+
+    The app SP typically only holds ``CAN_USE`` (granted at deploy time by
+    a human principal), not ``CAN_MANAGE``, so an in-app re-grant often
+    fails even when the privilege is already present. The warning text
+    points operators at the bootstrap script rather than implying the
+    privilege is missing.
     """
     granted: List[str] = []
     warnings: List[str] = []
@@ -101,8 +146,11 @@ def grant_can_use_on_project(
             granted.append(f"{app_name}: CAN_USE on project")
         else:
             warnings.append(
-                f"{app_name}: could not grant CAN_USE on project (need "
-                f"manage permission on the Lakebase project)"
+                f"{app_name}: could not re-grant CAN_USE on project "
+                f"(app SP needs CAN_MANAGE to grant; usually already "
+                f"applied by scripts/bootstrap/lakebase-perms.sh at "
+                f"deploy — re-run that script as a workspace admin if "
+                f"the SP still lacks CAN_USE)"
             )
     return granted, warnings
 
@@ -177,6 +225,10 @@ def grant_uc_catalog(
             logger.warning("UC catalog grant for %s failed: %s", app_name, exc)
             warnings.append(
                 f"{app_name}: UC catalog grant on {uc_catalog} failed "
-                f"({exc}). You may lack MANAGE on the catalog."
+                f"({exc}). The app SP needs MANAGE on the catalog to "
+                f"grant ALL_PRIVILEGES to itself — prefer re-running "
+                f"scripts/bootstrap/lakebase-perms.sh -c {uc_catalog} "
+                f"as a workspace admin (deploy applies this before the "
+                f"registry schema exists)."
             )
     return granted, warnings

--- a/src/back/core/graph_analysis/models.py
+++ b/src/back/core/graph_analysis/models.py
@@ -165,7 +165,8 @@ class EntityTypeProfile:
     avg_clustering: float            # mean clustering coefficient
     avg_betweenness: float           # mean betweenness centrality
     distinct_predicates: int         # distinct non-excluded predicate URIs used by instances
-    has_temporal_predicates: bool    # any predicate local-name contains date/time/ts/at/created
+    has_temporal_predicates: bool    # any camelCase/snake_case token is a temporal keyword
+
     is_flat: bool                    # heuristic: True when this type looks like a flat dataset
     flat_reasons: List[str] = field(default_factory=list)  # human-readable flags (empty if not flat)
 

--- a/src/back/core/graph_analysis/profiles.py
+++ b/src/back/core/graph_analysis/profiles.py
@@ -9,13 +9,22 @@ the app rather than in the job's SQL — keeping one copy means the wording of
 
 from __future__ import annotations
 
+import re
 from typing import Iterable, List, Set
 
-# Predicate local-name fragments that suggest time-series / temporal data.
+# Predicate local-name *tokens* that suggest time-series / temporal data.
+# Matched as whole camelCase / snake_case segments (not bare substrings), so
+# short keywords like ``dt`` / ``at`` do not fire inside ``assignedTo`` /
+# ``locatedIn``.
 TEMPORAL_KEYWORDS: Set[str] = {
     "time", "date", "timestamp", "ts", "at", "created", "modified", "dt",
     "start", "end", "recorded", "occurred", "measured",
 }
+
+# Split camelCase / PascalCase / snake_case / kebab-case into tokens.
+_TOKEN_SPLIT = re.compile(
+    r"[_\-\s]+|(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])"
+)
 
 
 def local_name(uri: str) -> str:
@@ -23,10 +32,20 @@ def local_name(uri: str) -> str:
     return (uri or "").rstrip("/").split("/")[-1].split("#")[-1].lower()
 
 
+def _local_tokens(uri: str) -> List[str]:
+    """Lower-cased camelCase / snake_case tokens of a predicate local name."""
+    raw = (uri or "").rstrip("/").split("/")[-1].split("#")[-1]
+    if not raw:
+        return []
+    return [part.lower() for part in _TOKEN_SPLIT.split(raw) if part]
+
+
 def has_temporal_predicates(predicates: Iterable[str]) -> bool:
-    """Whether any predicate's local name hints at temporal data."""
+    """Whether any predicate's local-name token hints at temporal data."""
     return any(
-        kw in local_name(p) for p in predicates for kw in TEMPORAL_KEYWORDS
+        token in TEMPORAL_KEYWORDS
+        for predicate in predicates
+        for token in _local_tokens(predicate)
     )
 
 

--- a/src/back/objects/domain/SettingsService.py
+++ b/src/back/objects/domain/SettingsService.py
@@ -17,6 +17,7 @@ from back.core.errors import (
 from shared.config.constants import HTTP_USER_AGENT
 from shared.config.settings import Settings
 from back.core.databricks import is_databricks_app
+from back.core.databricks.lakebase.grants import resolve_mcp_app_name
 from back.core.graphdb.neo4j.Neo4jStore import is_neo4j_password_from_secret
 from back.core.helpers import (
     get_databricks_client,
@@ -888,14 +889,12 @@ class SettingsService:
     def _registry_grant_app_names(settings: Settings) -> List[str]:
         """Apps whose service principals receive the registry grants.
 
-        The running app first, then the MCP companion (``MCP_APP_NAME`` env
-        → ``mcp-ontobricks`` default) — same resolution as the graph-DB
-        provisioning flow.
+        The running app first, then the MCP companion
+        (``resolve_mcp_app_name`` — same derivation as
+        ``scripts/deploy.config.sh`` / the graph-DB provisioning flow).
         """
         app_name = (getattr(settings, "ontobricks_app_name", "") or "").strip()
-        mcp_app_name = (
-            os.environ.get("MCP_APP_NAME", "").strip() or "mcp-ontobricks"
-        )
+        mcp_app_name = resolve_mcp_app_name(app_name)
         names: List[str] = []
         for candidate in (app_name, mcp_app_name):
             if candidate and candidate not in names:
@@ -2723,12 +2722,11 @@ class SettingsService:
             )
 
         # Apps whose service principals receive the grants: the running app
-        # first, then the MCP app (UI override -> MCP_APP_NAME env -> default).
+        # first, then the MCP app (UI override -> MCP_APP_NAME env ->
+        # mcp-{app_name} derived from the main app — matches deploy.config.sh).
         app_name = (settings.ontobricks_app_name or "").strip()
-        mcp_app_name = (
-            (params.get("mcp_app_name") or "").strip()
-            or os.environ.get("MCP_APP_NAME", "").strip()
-            or "mcp-ontobricks"
+        mcp_app_name = resolve_mcp_app_name(
+            app_name, explicit=(params.get("mcp_app_name") or "").strip()
         )
         app_names: List[str] = []
         for candidate in (app_name, mcp_app_name):

--- a/src/front/templates/settings.html
+++ b/src/front/templates/settings.html
@@ -585,7 +585,9 @@
                                         <div class="col-12 col-lg-6">
                                             <label for="provMcpAppName" class="form-label small fw-semibold mb-1">MCP app name</label>
                                             <input type="text" class="form-control form-control-sm font-monospace" id="provMcpAppName"
-                                                   maxlength="63" autocomplete="off" value="mcp-ontobricks" placeholder="mcp-ontobricks">
+                                                   maxlength="63" autocomplete="off" value=""
+                                                   placeholder="auto (mcp- + main app name)">
+                                            <div class="form-text small">Leave blank to derive <code>mcp-{main app}</code> (matches <code>deploy.config.sh</code>).</div>
                                         </div>
                                         <div class="col-12">
                                             <div class="form-check">

--- a/tests/e2e/dtwin/test_dtwin_flows.py
+++ b/tests/e2e/dtwin/test_dtwin_flows.py
@@ -37,9 +37,13 @@ class TestDigitalTwinSidebar:
         page.wait_for_load_state("domcontentloaded")
         link = page.locator('a[data-section="sigmagraph"]')
         assert link.is_visible()
+        label = (link.text_content() or "").lower()
+        # Sidebar label is "Explorer" (Graph Explorer); older builds said
+        # "Knowledge Graph" / "Graph".
         assert (
-            "knowledge" in (link.text_content() or "").lower()
-            or "graph" in (link.text_content() or "").lower()
+            "explorer" in label
+            or "knowledge" in label
+            or "graph" in label
         )
 
 

--- a/tests/e2e/navigation/test_navigation_flows.py
+++ b/tests/e2e/navigation/test_navigation_flows.py
@@ -5,7 +5,7 @@ Covers:
 - All six top-level routes load with the correct <title>.
 - Navbar brand navigates back to home.
 - Settings nav-link works.
-- Home page hero, domain panel, workflow cards, stat counters.
+- Home page hero, All Domains gateway, New Domain CTA.
 - About page content.
 """
 
@@ -71,18 +71,13 @@ class TestHomePage:
         assert page.locator("#domainGateway").count() >= 1
         assert page.locator("a.quick-link-sm").count() == 0
 
-    def test_workflow_cards_present(self, page, live_server):
+    def test_new_domain_cta_present(self, page, live_server):
+        # Replaces the old 3× `.workflow-card` strip and `#classCount` KPI
+        # band — Home is now the All Domains gateway + New Domain CTA.
         page.goto(live_server)
         page.wait_for_load_state("domcontentloaded")
-        cards = page.locator(".workflow-card")
-        assert cards.count() == 3
-
-    def test_stat_items_present(self, page, live_server):
-        page.goto(live_server)
-        page.wait_for_load_state("domcontentloaded")
-        assert page.locator("#classCount").is_visible()
-        assert page.locator("#propCount").is_visible()
-        assert page.locator("#mappingCount").is_visible()
+        assert page.locator("#domainGateway").is_visible()
+        assert page.get_by_role("button", name="New Domain").is_visible()
 
 
 class TestAboutPage:

--- a/tests/units/core/test_profiles.py
+++ b/tests/units/core/test_profiles.py
@@ -54,18 +54,12 @@ class TestTemporalDetection:
     def test_a_purely_structural_predicate_set_is_not_temporal(self):
         assert has_temporal_predicates([f"{NS}ownedBy"]) is False
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "Known false positive: the keywords are matched as bare substrings, "
-            "so the short ones fire inside unrelated words — 'dt' inside "
-            "'assignedto', 'at' inside 'locatedIn'. Matching on token "
-            "boundaries would fix it, but that changes what the UI reports for "
-            "existing domains, so it is a decision rather than a cleanup."
-        ),
-    )
     def test_short_keywords_should_not_match_inside_unrelated_words(self):
+        # Keywords like "dt" / "at" must be whole tokens (camelCase / snake_case
+        # segments), not bare substrings of unrelated predicates.
         assert has_temporal_predicates([f"{NS}assignedTo"]) is False
+        assert has_temporal_predicates([f"{NS}locatedIn"]) is False
+        assert has_temporal_predicates([f"{NS}status"]) is False
 
     def test_no_predicates_is_not_temporal(self):
         assert has_temporal_predicates([]) is False

--- a/tests/units/settings/test_bundle_job_resource.py
+++ b/tests/units/settings/test_bundle_job_resource.py
@@ -146,6 +146,63 @@ class TestDeployScriptPathResolution:
         assert (REPO_ROOT / "scripts/_internal/_lakebase-diag.sh").is_file()
 
 
+class TestBootstrapScriptsRepoRoot:
+    """scripts/bootstrap/* must cd to the repo root, not scripts/ (#133).
+
+    After the scripts/ reorg these lived one level deeper; ``cd "$SCRIPT_DIR/.."``
+    lands in ``scripts/``, so relative paths like
+    ``scripts/_internal/check-deploy-prerequisites.sh`` miss.
+    """
+
+    _BOOTSTRAP = (
+        "scripts/bootstrap/setup-lakebase.sh",
+        "scripts/bootstrap/app-permissions.sh",
+        "scripts/bootstrap/lakebase-perms.sh",
+    )
+
+    @pytest.mark.parametrize("rel", _BOOTSTRAP)
+    def test_climbs_out_of_bootstrap_to_repo_root(self, rel: str):
+        script = REPO_ROOT / rel
+        text = script.read_text()
+        # Must climb two levels (bootstrap → scripts → repo), not one.
+        assert 'cd "$SCRIPT_DIR/../.."' in text or 'REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"' in text
+        assert 'cd "$SCRIPT_DIR/.."\n' not in text
+        root = script.resolve().parents[2]
+        assert root == REPO_ROOT
+        assert (root / "scripts/_internal/check-deploy-prerequisites.sh").is_file()
+        assert (root / "scripts/deploy.config.sh").is_file()
+
+    def test_setup_lakebase_does_not_document_removed_default_segment(self):
+        text = (REPO_ROOT / "scripts/bootstrap/setup-lakebase.sh").read_text()
+        assert "DEFAULT_LAKEBASE_DATABASE_RESOURCE_SEGMENT" not in text
+        assert "DEFAULT_LAKEBASE_DATABASE" in text
+        assert "LAKEBASE_DATABASE_RESOURCE_SEGMENT" in text
+
+
+class TestAppPermissionsInBundle:
+    """App ACL (CAN_USE) must nest under resources.apps.*, not top-level (#134).
+
+    Top-level ``permissions:`` only accepts CAN_MANAGE / CAN_VIEW / CAN_RUN —
+    putting CAN_USE there fails ``databricks bundle validate``.
+    """
+
+    def test_no_top_level_permissions_block(self):
+        data = yaml.safe_load((REPO_ROOT / "databricks.yml").read_text())
+        assert "permissions" not in data, (
+            "top-level permissions: rejects CAN_USE; nest under resources.apps.*"
+        )
+
+    def test_each_app_declares_can_use_for_users(self):
+        data = yaml.safe_load((REPO_ROOT / "databricks.yml").read_text())
+        apps = data["resources"]["apps"]
+        for key in ("ontobricks_dev_app", "mcp_ontobricks_app"):
+            perms = apps[key].get("permissions") or []
+            levels = {p.get("level") for p in perms}
+            assert "CAN_MANAGE" in levels, f"{key} missing CAN_MANAGE"
+            assert "CAN_USE" in levels, f"{key} missing CAN_USE"
+            assert any(p.get("group_name") == "users" for p in perms)
+
+
 class TestAnalyticsJobPermissionBootstrap:
     """The app SP must get CAN_MANAGE_RUN on the analytics job at deploy time.
 

--- a/tests/units/settings/test_deploy_app_rename_guard.py
+++ b/tests/units/settings/test_deploy_app_rename_guard.py
@@ -148,40 +148,29 @@ class TestDeployWiring:
         after = body.split("_preflight_check_app_rename", 2)[2]
         assert "die" in after.split("\n\n")[0]
 
-    def test_the_secret_scope_check_is_wired(self):
-        assert "_preflight_check_secret_scope" in DEPLOY.read_text()
 
+class TestDeployDoesNotBindNeo4jSecrets:
+    """Neo4j is optional — DAB must not require a workspace secret (GH #136)."""
 
-class TestSecretScopeIsConfigurable:
-    """The bundle hardcoded a scope named ``ontobricks``, which never existed."""
-
-    def test_the_bundle_no_longer_hardcodes_the_scope(self):
+    def test_the_bundle_has_no_neo4j_secret_overlay(self):
         bundle = yaml.safe_load(BUNDLE.read_text())
         app = bundle["targets"][TARGET]["resources"]["apps"][KEY]
-        secrets = [r for r in app["resources"] if "secret" in r]
-        assert secrets, "expected the neo4j-password secret binding"
-        for res in secrets:
-            assert res["secret"]["scope"] == "${var.neo4j_secret_scope}"
+        secrets = [r for r in app.get("resources") or [] if "secret" in r]
+        assert secrets == [], "DAB must not bind neo4j-password (optional engine)"
 
-    def test_the_variable_is_declared_with_a_default(self):
+    def test_the_neo4j_secret_scope_variable_is_gone(self):
         bundle = yaml.safe_load(BUNDLE.read_text())
-        var = bundle["variables"]["neo4j_secret_scope"]
-        assert var.get("default")
+        assert "neo4j_secret_scope" not in bundle.get("variables", {})
 
-    def test_the_deploy_passes_the_variable(self):
-        assert "--var=neo4j_secret_scope=${NEO4J_SECRET_SCOPE}" in DEPLOY.read_text()
+    def test_deploy_does_not_pass_neo4j_secret_scope(self):
+        assert "neo4j_secret_scope" not in DEPLOY.read_text()
 
-    def test_the_config_exports_it(self):
+    def test_deploy_config_does_not_export_neo4j_secret_scope(self):
         body = CONFIG.read_text()
-        assert "DEFAULT_NEO4J_SECRET_SCOPE=" in body
-        assert "export NEO4J_SECRET_SCOPE=" in body
+        assert "NEO4J_SECRET_SCOPE" not in body
+        assert "DEFAULT_NEO4J_SECRET_SCOPE" not in body
 
-    def test_the_default_matches_the_config(self):
-        """Drift here means a deploy that works only when the var is passed."""
-        bundle = yaml.safe_load(BUNDLE.read_text())
-        default = bundle["variables"]["neo4j_secret_scope"]["default"]
-        assert f'DEFAULT_NEO4J_SECRET_SCOPE="{default}"' in CONFIG.read_text()
-
-    @pytest.mark.parametrize("scope", ["ontobricks"])
-    def test_the_nonexistent_scope_is_gone(self, scope):
-        assert f"scope: {scope}\n" not in BUNDLE.read_text()
+    def test_instance_target_generator_does_not_bind_neo4j_secret(self):
+        gen = (ROOT / "scripts/_internal/_ensure-instance-target.sh").read_text()
+        assert "key: neo4j-password" not in gen
+        assert "neo4j_secret_scope" not in gen

--- a/tests/units/settings/test_mcp_app_name_resolution.py
+++ b/tests/units/settings/test_mcp_app_name_resolution.py
@@ -1,0 +1,60 @@
+"""MCP companion app name must follow deploy.config.sh (issue #137).
+
+``scripts/deploy.config.sh`` derives ``MCP_APP_NAME=mcp-${APP_NAME}``
+(e.g. ``ontobricks-07x`` → ``mcp-ontobricks-07x``). In-app registry /
+graph grants historically defaulted to the bare ``mcp-ontobricks`` string,
+so Initialize skipped MCP grants on every instance-suffixed deploy.
+"""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from back.core.databricks.lakebase.grants import resolve_mcp_app_name
+from back.objects.domain.SettingsService import SettingsService
+
+
+class TestResolveMcpAppName:
+    def test_explicit_override_wins(self):
+        assert (
+            resolve_mcp_app_name(
+                app_name="ontobricks-07x", explicit="mcp-custom"
+            )
+            == "mcp-custom"
+        )
+
+    def test_derives_mcp_prefix_from_main_app(self):
+        assert resolve_mcp_app_name(app_name="ontobricks-07x") == "mcp-ontobricks-07x"
+
+    def test_env_override_when_no_explicit(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("MCP_APP_NAME", "mcp-from-env")
+        assert resolve_mcp_app_name(app_name="ontobricks-07x") == "mcp-from-env"
+
+    def test_fallback_when_no_app_name(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("MCP_APP_NAME", raising=False)
+        assert resolve_mcp_app_name(app_name="") == "mcp-ontobricks"
+
+    def test_does_not_double_prefix_mcp_apps(self):
+        assert resolve_mcp_app_name(app_name="mcp-ontobricks-07x") == "mcp-ontobricks-07x"
+
+
+class TestRegistryGrantAppNames:
+    def test_uses_suffixed_mcp_companion(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("MCP_APP_NAME", raising=False)
+        settings = SimpleNamespace(ontobricks_app_name="ontobricks-07x")
+        assert SettingsService._registry_grant_app_names(settings) == [
+            "ontobricks-07x",
+            "mcp-ontobricks-07x",
+        ]
+
+    def test_env_still_overrides_derived_name(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("MCP_APP_NAME", "mcp-override")
+        settings = SimpleNamespace(ontobricks_app_name="ontobricks-07x")
+        assert SettingsService._registry_grant_app_names(settings) == [
+            "ontobricks-07x",
+            "mcp-override",
+        ]


### PR DESCRIPTION
<!--
PR Template — Cursor-Native Superpowers (CNS) methodology
See docs/PR_REVIEW_CHECKLIST.md for the reviewer's pass.
-->

## Summary

<!-- One paragraph: what changes, why now. Avoid restating the diff. -->

## Linked Issue / milestone

Closes #<issue-number>. Part of `M<n>.<phase>` in `.planning/ROADMAP.md`.

## Plan

`.planning/<slug>/PLAN.md`

<!-- For T4 (agent feature) work, link the SPEC too: -->
<!-- `.planning/<slug>/SPEC.md` -->

## Type of change

- [ ] feat — new feature
- [ ] fix — bug fix
- [ ] docs — documentation only
- [ ] refactor — no behaviour change
- [ ] test — tests only
- [ ] perf — perf improvement
- [ ] ci / build / chore — tooling

## Author checklist

- [ ] Conventional Commit PR title (`<type>(<scope>): <subject>`).
- [ ] `changelogs/<today>.log` updated with title + context + numbered changes + files + test result.
- [ ] Tests added or modified for every behaviour change.
- [ ] `uv run pytest tests/<scope>/` green locally.
- [ ] `pre-commit run --all-files` clean (or skipped hooks documented).
- [ ] If `src/agents/**` or any MLflow-traced LLM path changed:
  - [ ] `SPEC.md` present in `.planning/<slug>/`.
  - [ ] `tests/eval/datasets/<agent>/dataset.jsonl` has ≥20 examples (new) or ≥10 (change).
  - [ ] MLflow eval run URI in PR body below.
  - [ ] Judge score ≥ baseline + delta, or explicit waiver here.
- [ ] If `src/mcp-server/**` changed: `uv run pytest tests/mcp/ -m mcp` green.
- [ ] No `gsd-*` references re-introduced.

## MLflow eval run

<!-- For agent PRs only. Paste the run URI: -->
<!-- https://<workspace>.databricks.com/ml/experiments/<id>/runs/<run-id> -->

## Test plan

- [ ] `uv run pytest tests/ -m "not e2e and not property and not eval" --cov-fail-under=90`
- [ ] Per-package coverage thresholds (`scripts/check_coverage.py`) green for touched packages.
- [ ] If new MCP tool: `uv run pytest tests/mcp/integration/test_tool_schemas.py` includes it.

## Reviewer hint

See `docs/PR_REVIEW_CHECKLIST.md`. Numbered items map 1:1 to comments — `#3: missing OntoBricksError subclass for new condition` is more useful than "fix error handling".
