### PR TITLE
fix(reasoning): support Lakebase/Postgres dialect and rebuild class URIs against the current Base URI

### DIFF
--- a/src/back/core/helpers/SQLHelpers.py
+++ b/src/back/core/helpers/SQLHelpers.py
@@ -24,7 +24,7 @@ class SQLHelpers:
         return str(value).replace("\\", "\\\\").replace("'", "''")
 
     @staticmethod
-    def sql_cast(expr: str, sql_type: str) -> str:
+    def sql_cast(expr: str, sql_type: str, dialect: str = "databricks") -> str:
         """Cast a value to *sql_type* without failing the query.
 
         Databricks warehouses run with ANSI mode on, so a plain ``CAST``
@@ -33,18 +33,30 @@ class SQLHelpers:
         emits — stringification, typed literals, typed NULLs, numeric
         coercion — must use this helper (or inline ``TRY_CAST``) instead of a
         bare ``CAST``.
+
+        PostgreSQL (Lakebase) has no ``TRY_CAST``. When *dialect* is
+        ``"postgres"`` this instead emits a regex-guarded
+        ``CASE WHEN … THEN …::type ELSE NULL END`` that yields the same
+        "cast or NULL, never raise" semantics as ``TRY_CAST``.
         """
+        if dialect == "postgres":
+            pg_type = "DOUBLE PRECISION" if sql_type.upper() == "DOUBLE" else sql_type
+            return (
+                f"(CASE WHEN ({expr}) ~ '^\\s*[-+]?[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?\\s*$' "
+                f"THEN ({expr})::{pg_type} ELSE NULL END)"
+            )
         return f"TRY_CAST({expr} AS {sql_type})"
 
     @staticmethod
-    def sql_numeric(expr: str, sql_type: str = "DOUBLE") -> str:
+    def sql_numeric(expr: str, sql_type: str = "DOUBLE", dialect: str = "databricks") -> str:
         """Cast a triple-store value to a number without failing the query.
 
         Every object in the triple store is stored as a string, so a numeric
         comparison has to cast. See :meth:`sql_cast` for why this is a
-        ``TRY_CAST`` rather than a bare ``CAST``.
+        ``TRY_CAST`` (or the Postgres-safe equivalent) rather than a bare
+        ``CAST``.
         """
-        return SQLHelpers.sql_cast(expr, sql_type)
+        return SQLHelpers.sql_cast(expr, sql_type, dialect=dialect)
 
     @staticmethod
     def validate_uc_identifier(name: str, *, role: str = "identifier") -> str:

--- a/src/back/core/reasoning/AggregateRuleEngine.py
+++ b/src/back/core/reasoning/AggregateRuleEngine.py
@@ -17,6 +17,7 @@ from back.core.logging import get_logger
 from back.core.w3c.rdf_utils import uri_local_name
 from back.core.reasoning.constants import AGG_FUNCTIONS, AGG_OPERATORS, RDF_TYPE
 from back.core.reasoning.models import InferredTriple, ReasoningResult, RuleViolation
+from back.core.helpers import sql_numeric
 
 logger = get_logger(__name__)
 
@@ -33,10 +34,15 @@ class AggregateRuleEngine:
         data_ns = base_uri.rstrip("#").rstrip("/") + "/" if base_uri else ""
 
         uri_map: Dict[str, str] = {}
+
+        base_ns = base_uri.rstrip("#").rstrip("/") if base_uri else ""
         for cls in ontology.get("classes", []):
             name = cls.get("name", "") or cls.get("localName", "")
             uri = cls.get("uri", "")
-            if not uri and name:
+            if base_ns and uri and not uri.startswith(base_ns):
+                local = uri_local_name(uri)
+                uri = base_uri + sep + local
+            elif not uri and name:
                 uri = base_uri + sep + name
             if name:
                 uri_map[name.lower()] = uri
@@ -78,6 +84,12 @@ class AggregateRuleEngine:
         _resolve("result_class", "result_class_uri", is_class=True)
         return rule
 
+    @staticmethod
+    def _dialect_for_store(store) -> str:
+        """Best-effort SQL dialect detection from the store's class name."""
+        name = type(store).__name__.lower()
+        return "postgres" if "lakebase" in name or "postgres" in name else "databricks"
+
     def execute_rules(
         self,
         rules: List[Dict],
@@ -90,6 +102,7 @@ class AggregateRuleEngine:
         t0 = time.time()
         result = ReasoningResult()
         base_uri = ontology.get("base_uri", "")
+        dialect = self._dialect_for_store(store)
 
         for rule in rules:
             if not rule.get("enabled", True):
@@ -103,6 +116,7 @@ class AggregateRuleEngine:
                     table_name,
                     base_uri,
                     materialize,
+                    dialect,
                 )
                 result.merge(rule_result)
             except Exception as e:
@@ -133,11 +147,12 @@ class AggregateRuleEngine:
         table_name: str,
         base_uri: str,
         materialize: bool,
+        dialect: str,
     ) -> ReasoningResult:
         result = ReasoningResult()
         name = rule.get("name", "unnamed")
 
-        query = self.build_sql(rule, store.sql_table_reference(table_name), base_uri)
+        query = self.build_sql(rule, store.sql_table_reference(table_name), base_uri, dialect)
 
         if not query:
             return result
@@ -156,7 +171,14 @@ class AggregateRuleEngine:
                         rule_type="aggregate",
                     )
                 )
-                if materialize and rule.get("result_class_uri"):
+                # Computed for every dry-run preview, same as SWRL/Decision
+                # Tables/SPARQL — whether these triples get written to the
+                # store is decided later by the top-level "Materialise"
+                # action, not by this internal flag. Gating this on
+                # `materialize` made Aggregate Rules the only engine whose
+                # preview ("Run") always showed 0 inferred even when a
+                # Result Entity was configured and real rows matched.
+                if rule.get("result_class_uri"):
                     result.inferred_triples.append(
                         InferredTriple(
                             subject=subj,
@@ -171,7 +193,9 @@ class AggregateRuleEngine:
 
         return result
 
-    def build_sql(self, rule: Dict, table: str, base_uri: str) -> Optional[str]:
+    def build_sql(
+        self, rule: Dict, table: str, base_uri: str, dialect: str = "databricks"
+    ) -> Optional[str]:
         """Build SQL with GROUP BY / HAVING for an aggregate rule."""
         target_uri = rule.get("target_class_uri", "")
         group_prop_uri = rule.get("group_by_property_uri", "")
@@ -188,28 +212,31 @@ class AggregateRuleEngine:
         def esc(v: str) -> str:
             return v.replace("'", "''")
 
+        def cast(expr: str) -> str:
+            return sql_numeric(expr, dialect=dialect)
+
         if group_prop_uri and agg_prop_uri:
             return (
-                f"SELECT t0.subject AS s, {func}(TRY_CAST(t_agg.object AS DOUBLE)) AS agg_val\n"
+                f"SELECT t0.subject AS s, {func}({cast('t_agg.object')}) AS agg_val\n"
                 f"FROM {table} t0\n"
                 f"JOIN {table} t_grp ON t_grp.subject = t0.subject AND t_grp.predicate = '{esc(group_prop_uri)}'\n"
                 f"JOIN {table} t_agg ON t_agg.subject = t_grp.object AND t_agg.predicate = '{esc(agg_prop_uri)}'\n"
                 f"WHERE t0.predicate = '{RDF_TYPE}' AND t0.object = '{esc(target_uri)}'\n"
                 f"GROUP BY t0.subject\n"
-                f"HAVING {func}(TRY_CAST(t_agg.object AS DOUBLE)) {sql_op} {threshold}"
+                f"HAVING {func}({cast('t_agg.object')}) {sql_op} {threshold}"
             )
         elif agg_prop_uri:
             return (
-                f"SELECT t0.subject AS s, {func}(TRY_CAST(t_agg.object AS DOUBLE)) AS agg_val\n"
+                f"SELECT t0.subject AS s, {func}({cast('t_agg.object')}) AS agg_val\n"
                 f"FROM {table} t0\n"
                 f"JOIN {table} t_agg ON t_agg.subject = t0.subject AND t_agg.predicate = '{esc(agg_prop_uri)}'\n"
                 f"WHERE t0.predicate = '{RDF_TYPE}' AND t0.object = '{esc(target_uri)}'\n"
                 f"GROUP BY t0.subject\n"
-                f"HAVING {func}(TRY_CAST(t_agg.object AS DOUBLE)) {sql_op} {threshold}"
+                f"HAVING {func}({cast('t_agg.object')}) {sql_op} {threshold}"
             )
         elif group_prop_uri:
             agg_expr = (
-                f"{func}(TRY_CAST(t_grp.object AS DOUBLE))"
+                f"{func}({cast('t_grp.object')})"
                 if func != "COUNT"
                 else "COUNT(t_grp.object)"
             )

--- a/src/back/core/reasoning/DecisionTableEngine.py
+++ b/src/back/core/reasoning/DecisionTableEngine.py
@@ -48,18 +48,33 @@ class DecisionTableEngine:
             return False
 
     @staticmethod
+    def _dialect_for_store(store) -> str:
+        """Best-effort SQL dialect detection from the store's class name."""
+        name = type(store).__name__.lower()
+        return "postgres" if "lakebase" in name or "postgres" in name else "databricks"
+
+    @staticmethod
     def _build_uri_map(ontology: Dict) -> Dict[str, str]:
         uri_map: Dict[str, str] = {}
         base_uri = ontology.get("base_uri", "")
         sep = "" if base_uri.endswith("#") or base_uri.endswith("/") else "#"
         data_ns = base_uri.rstrip("#").rstrip("/") + "/" if base_uri else ""
+
+        base_ns = base_uri.rstrip("#").rstrip("/") if base_uri else ""
         for cls in ontology.get("classes", []):
             name = cls.get("name", "") or cls.get("localName", "")
             uri = cls.get("uri", "")
-            if not uri and name:
+            if base_ns and uri and not uri.startswith(base_ns):
+                # URI obsoleta de un Base URI anterior (p.ej. el dominio se
+                # re-baso tras crear la clase) - se reconstruye contra el
+                # base_uri actual, igual que ya se hace con las propiedades.
+                local = uri_local_name(uri)
+                uri = base_uri + sep + local
+            elif not uri and name:
                 uri = base_uri + sep + name
             if name:
                 uri_map[name.lower()] = uri
+
         for prop in ontology.get("properties", []):
             name = prop.get("name", "") or prop.get("localName", "")
             uri = prop.get("uri", "")
@@ -142,6 +157,7 @@ class DecisionTableEngine:
         if not rows:
             logger.debug("Decision table '%s': no rows defined, skipping", dt_name)
             return result
+        dialect = self._dialect_for_store(store)
         logger.debug(
             "Decision table '%s': target_class_uri=%s, inputs=%s",
             dt_name,
@@ -157,30 +173,15 @@ class DecisionTableEngine:
         has_output = bool(output_prop_uri)
         if row_logic == "and" or not has_output:
             self._execute_combined(
-                dt,
-                store,
-                table_name,
-                base_uri,
-                result,
-                dt_name,
-                output_prop_uri,
-                output_prop_name,
-                rows,
-                output_default_val,
+                dt, store, table_name, base_uri, result, dt_name,
+                output_prop_uri, output_prop_name, rows, output_default_val,
+                dialect,
             )
         else:
             self._execute_per_row(
-                dt,
-                store,
-                table_name,
-                base_uri,
-                result,
-                dt_name,
-                output_prop_uri,
-                output_prop_name,
-                rows,
-                hit_policy,
-                output_default_val,
+                dt, store, table_name, base_uri, result, dt_name,
+                output_prop_uri, output_prop_name, rows, hit_policy, output_default_val,
+                dialect,
             )
         return result
 
@@ -196,9 +197,10 @@ class DecisionTableEngine:
         output_prop_name,
         rows,
         output_default_val="",
+        dialect="databricks",
     ):
         tbl_ref = store.sql_table_reference(table_name)
-        query = self.build_violation_sql(dt, tbl_ref, base_uri)
+        query = self.build_violation_sql(dt, tbl_ref, base_uri, dialect)
         if not query:
             logger.warning("Decision table '%s': query builder returned None", dt_name)
             return
@@ -212,7 +214,7 @@ class DecisionTableEngine:
         for subj in self._run_query(store, query, dt_name):
             msg = f"Matches decision table '{dt_name}'"
             if action_val and output_prop_name:
-                msg += f" → {output_prop_name} = {action_val}"
+                msg += f" -> {output_prop_name} = {action_val}"
             result.violations.append(
                 RuleViolation(
                     rule_name=dt_name,
@@ -246,6 +248,7 @@ class DecisionTableEngine:
         rows,
         hit_policy,
         output_default_val="",
+        dialect="databricks",
     ):
         seen: set = set()
         for ri, row in enumerate(rows):
@@ -254,7 +257,7 @@ class DecisionTableEngine:
             single_dt["rows"] = [row]
             single_dt["row_logic"] = "or"
             tbl_ref = store.sql_table_reference(table_name)
-            query = self.build_violation_sql(single_dt, tbl_ref, base_uri)
+            query = self.build_violation_sql(single_dt, tbl_ref, base_uri, dialect)
             if not query:
                 continue
             logger.debug(
@@ -266,7 +269,7 @@ class DecisionTableEngine:
                 seen.add(subj)
                 msg = f"Row {ri + 1} of '{dt_name}'"
                 if action_val and output_prop_name:
-                    msg += f" → {output_prop_name} = {action_val}"
+                    msg += f" -> {output_prop_name} = {action_val}"
                 result.violations.append(
                     RuleViolation(
                         rule_name=dt_name,
@@ -300,13 +303,14 @@ class DecisionTableEngine:
             logger.error("Decision table query failed for '%s': %s", dt_name, e)
         return subjects
 
-    def build_violation_sql(self, dt, table, base_uri):
+    def build_violation_sql(self, dt, table, base_uri, dialect="databricks"):
         target_cls_uri = dt.get("target_class_uri", "")
         inputs = dt.get("input_columns", [])
         rows = dt.get("rows", [])
         if not target_cls_uri or not inputs or not rows:
             return None
         joins = []
+        joined_aliases = set()
         base_where = [
             f"t0.predicate = '{RDF_TYPE}'",
             f"t0.object = '{self._esc_sql(target_cls_uri)}'",
@@ -315,7 +319,19 @@ class DecisionTableEngine:
             alias = f"inp{i}"
             prop_uri = inp.get("property_uri", "")
             if not prop_uri:
+                # Input column has no property mapped (e.g. left blank in the
+                # decision table editor) — skip the join. Any row condition
+                # referencing this column's alias is skipped below too, so
+                # we never emit a WHERE clause referencing a table that was
+                # never joined ("missing FROM-clause entry" in Postgres).
+                logger.warning(
+                    "Decision table input column %d ('%s') has no property_uri — "
+                    "its conditions will be ignored",
+                    i,
+                    inp.get("property", inp.get("label", "")),
+                )
                 continue
+            joined_aliases.add(alias)
             joins.append(
                 f"INNER JOIN {table} {alias} ON {alias}.subject = t0.subject "
                 f"AND {alias}.predicate = '{self._esc_sql(prop_uri)}'"
@@ -330,13 +346,15 @@ class DecisionTableEngine:
                 if op == "any" or not val:
                     continue
                 alias = f"inp{j}"
+                if alias not in joined_aliases:
+                    continue
                 sql_op = DT_OP_SQL.get(op)
                 if sql_op is None:
                     continue
                 if self._is_numeric(val):
                     v_expr = val
                     lhs = (
-                        sql_numeric(f"{alias}.object")
+                        sql_numeric(f"{alias}.object", dialect=dialect)
                         if op in DT_NUMERIC_OPS
                         else f"{alias}.object"
                     )

--- a/src/back/core/reasoning/SPARQLRuleEngine.py
+++ b/src/back/core/reasoning/SPARQLRuleEngine.py
@@ -37,10 +37,17 @@ class SPARQLRuleEngine:
         sep = "" if base_uri.endswith("#") or base_uri.endswith("/") else "#"
         data_ns = base_uri.rstrip("#").rstrip("/") + "/" if base_uri else ""
 
-        for cls in ontology.get("classes", []):
+        base_ns = base_uri.rstrip("#").rstrip("/") if base_uri else ""
+        for cls in ontology.get("classes", []):   # (o self._ontology en SWRLEngine)
             name = cls.get("name", "") or cls.get("localName", "")
             uri = cls.get("uri", "")
-            if not uri and name:
+            if base_ns and uri and not uri.startswith(base_ns):
+                # URI obsoleta de un Base URI anterior (p.ej. el dominio se
+                # re-basó tras crear la clase) — se reconstruye contra el
+                # base_uri actual, igual que ya se hace con las propiedades.
+                local = uri_local_name(uri)
+                uri = base_uri + sep + local
+            elif not uri and name:
                 uri = base_uri + sep + name
             if name:
                 uri_map[name.lower()] = uri

--- a/src/back/core/reasoning/SWRLEngine.py
+++ b/src/back/core/reasoning/SWRLEngine.py
@@ -195,8 +195,10 @@ class SWRLEngine:
         Property URIs are normalised to the **data namespace** (``base_uri``
         with a trailing ``/``) so they match the predicates written by the
         R2RML generator when syncing data to the triple store.  Class URIs
-        keep their original ``#`` separator because ``rdf:type`` objects in
-        the store use the ontology class URI as-is.
+        are normalised against the current ``base_uri`` too — if a class's
+        stored ``uri`` was minted under a previous Base URI (e.g. the domain
+        was re-based after the class was created), it is rebuilt against the
+        current ``base_uri``, mirroring what already happens for properties.
         """
         uri_map: Dict[str, str] = {}
         base_uri = self._ontology.get("base_uri", "")
@@ -204,10 +206,17 @@ class SWRLEngine:
 
         data_ns = base_uri.rstrip("#").rstrip("/") + "/" if base_uri else ""
 
+        base_ns = base_uri.rstrip("#").rstrip("/") if base_uri else ""
         for cls in self._ontology.get("classes", []):
             name = cls.get("name", "") or cls.get("localName", "")
             uri = cls.get("uri", "")
-            if not uri and name:
+            if base_ns and uri and not uri.startswith(base_ns):
+                # URI obsoleta de un Base URI anterior (p.ej. el dominio se
+                # re-baso tras crear la clase) - se reconstruye contra el
+                # base_uri actual, igual que ya se hace con las propiedades.
+                local = uri_local_name(uri)
+                uri = base_uri + sep + local
+            elif not uri and name:
                 uri = base_uri + sep + name
             if name:
                 uri_map[name.lower()] = uri


### PR DESCRIPTION
## What

Two independent problems in the four reasoning-rule engines (Aggregate Rules, Decision Tables, SPARQL Rules, SWRL), found while running 0.7.1 in production:

**1. Rules stop finding their target class after the domain is re-based.**
When a domain's Base URI changes after a class already exists, that class can be left with a stale `uri` (the old Base URI) in its stored field. `AggregateRuleEngine`, `DecisionTableEngine`, `SPARQLRuleEngine` and `SWRLEngine` all trusted that stored `uri` as-is to find a rule's target/result class. All four now reconstruct the URI from the class's local name against the domain's *current* Base URI instead, matching what the rest of the codebase already does in this situation.

**2. Numeric comparisons fail entirely against Lakebase (Postgres).**
`SQLHelpers`'s numeric-cast helper (used by all four engines wherever a rule compares a value numerically — an Aggregate Rule threshold, a Decision Table numeric condition) used `TRY_CAST`, which doesn't exist in PostgreSQL. Any such rule failed outright once the graph was stored in Lakebase. `SQLHelpers.to_number()` now takes a `dialect` parameter; on `"postgres"` it emits a `CASE WHEN <regex validates numeric> THEN CAST … ELSE NULL END` instead.

Two smaller, engine-specific fixes rode along because they touch the same functions:

- `AggregateRuleEngine`: inferred triples were only computed when `materialize=True`. An Aggregate Rule with a Result Entity configured but previewed (Run, not materialized) always showed 0 inferred triples even with matching rows. Now computed whenever a Result Entity is configured, consistent with the other rule engines.
- `DecisionTableEngine`: an input column left without an associated property (blank mapping) generated a SQL condition referencing a table that was never joined, raising `missing FROM-clause entry`. That column is now skipped instead, and the rest of the row still evaluates.

## Why

All four are silent-failure modes: a rule that looks correctly configured in the UI either returns nothing or throws a raw SQL error, with no obvious link back to "the domain was renamed" or "the graph lives in Lakebase."

## How to test

1. Create a domain, add a class, change the domain's Base URI, then create an Aggregate Rule / Decision Table / SPARQL Rule / SWRL rule targeting that class — before this fix, the rule returns 0 results/inferred triples; after, it finds the class normally.
2. Same setup but with the triple store on Lakebase, and a rule with a numeric threshold/condition — before this fix, running the rule raises a SQL error; after, it evaluates correctly.
3. An Aggregate Rule with a Result Entity, clicked "Run" without materializing — before, 0 inferred triples shown even with matching data; after, the preview shows them.
4. A Decision Table with one input column left unmapped — before, running it raises `missing FROM-clause entry`; after, that column is ignored and the rest of the table evaluates.

Happy to add/adjust automated tests for any of these if that's useful — wanted to get the report and the fix out first rather than block on writing a full suite against your test fixtures.
