### PR TITLE
fix(mapping): read Manual Mapping save fields from panel state, send excluded/attribute mappings

### DIFF
--- a/src/front/static/mapping/js/mapping-manual.js
+++ b/src/front/static/mapping/js/mapping-manual.js
@@ -565,8 +565,10 @@ window.ManualModule = {
             if (type === 'entity') {
                 // Get values from the panel (same IDs as Designer)
                 const sqlQuery = document.getElementById('epSqlQuery')?.value?.trim();
-                const idColumn = document.getElementById('epSummaryId')?.textContent;
-                const labelColumn = document.getElementById('epSummaryLabel')?.textContent;
+                //JERRY const idColumn = document.getElementById('epSummaryId')?.textContent;
+                //JERRY const labelColumn = document.getElementById('epSummaryLabel')?.textContent;
+                const idColumn    = EntityPanelState.idColumn; //JERRY
+                const labelColumn = EntityPanelState.labelColumn; //JERRY
                 
                 if (!sqlQuery) {
                     showNotification('Please enter a SQL query first', 'warning');
@@ -574,14 +576,25 @@ window.ManualModule = {
                     saveBtn.disabled = false;
                     return;
                 }
-                
+
+                const filteredAttrMappings = Object.fromEntries(
+                    Object.entries(EntityPanelState.attributeMappings).filter(
+                        ([k]) => !EntityPanelState.excludedAttributes.includes(k)
+                    )
+                );
+
                 const mapping = {
                     ontology_class: uri,
-                    class_name: label || name,
+                    ontology_class_label: label || name,
                     sql_query: sqlQuery,
                     id_column: idColumn && idColumn !== 'Not set' ? idColumn : null,
-                    label_column: labelColumn && labelColumn !== 'Not set' ? labelColumn : null
+                    label_column: labelColumn && labelColumn !== 'Not set' ? labelColumn : null,
+                    attribute_mappings: filteredAttrMappings
                 };
+
+                if (EntityPanelState.excludedAttributes.length > 0) {
+                    mapping.excluded_attributes = [...EntityPanelState.excludedAttributes];
+                }
                 
                 const response = await fetch('/mapping/entity/add', {
                     method: 'POST',
@@ -604,9 +617,9 @@ window.ManualModule = {
                 }
             } else {
                 // Get values from the panel (same IDs as Designer)
-                const sqlQuery = document.getElementById('rpSqlQuery')?.value?.trim();
-                const sourceColumn = document.getElementById('rpSummarySource')?.textContent;
-                const targetColumn = document.getElementById('rpSummaryTarget')?.textContent;
+                const sqlQuery     = document.getElementById('rpSqlQuery')?.value?.trim();
+                const sourceColumn = RelPanelState.sourceIdColumn;
+                const targetColumn = RelPanelState.targetIdColumn;
                 
                 if (!sqlQuery) {
                     showNotification('Please enter a SQL query first', 'warning');
@@ -615,13 +628,30 @@ window.ManualModule = {
                     return;
                 }
                 
+                const filteredAttrMappings = Object.fromEntries(
+                    Object.entries(RelPanelState.attributeMappings).filter(
+                        ([k]) => !RelPanelState.excludedAttributes.includes(k)
+                    )
+                );
+                const existingRel = MappingState.config.relationships.find(m => m.property === uri) || {};
+
                 const mapping = {
                     property: uri,
-                    property_name: label || name,
+                    property_label: label || name,
                     sql_query: sqlQuery,
+                    source_class: existingRel.source_class || '',
+                    source_class_label: existingRel.source_class_label || '',
+                    target_class: existingRel.target_class || '',
+                    target_class_label: existingRel.target_class_label || '',
                     source_id_column: sourceColumn && sourceColumn !== 'Not set' ? sourceColumn : null,
-                    target_id_column: targetColumn && targetColumn !== 'Not set' ? targetColumn : null
+                    target_id_column: targetColumn && targetColumn !== 'Not set' ? targetColumn : null,
+                    direction: existingRel.direction || 'forward',
+                    attribute_mappings: filteredAttrMappings
                 };
+
+                if (RelPanelState.excludedAttributes.length > 0) {
+                    mapping.excluded_attributes = [...RelPanelState.excludedAttributes];
+                }
                 
                 const response = await fetch('/mapping/relationship/add', {
                     method: 'POST',


### PR DESCRIPTION
## What

Two related bugs in saving from Manual Mapping (the SQL-first alternative to the Designer for creating mappings directly):

- **Entity save**: `id_column`/`label_column` were read from the panel's visual summary text (which can be stale, or show "Not set" even when the panel's actual state is valid), instead of from the panel's own internal state (`EntityPanelState`). The save call now also sends `attribute_mappings` and, when present, `excluded_attributes` — neither was persisted from this screen before at all.
- **Relationship save**: `sourceColumn`/`targetColumn` are likewise now read from `RelPanelState` instead of the visual summary. The save call now also sends `source_class`, `target_class` and `direction` (recovered from the existing mapping when there is one), plus `attribute_mappings`/`excluded_attributes`.

## Why

Reading from the rendered summary text meant a save could silently capture the wrong (or empty) ID/label/source/target column whenever the summary hadn't caught up with the panel's real state. Not sending `attribute_mappings`/`excluded_attributes` meant those were lost entirely when saving from this screen. Not sending `source_class`/`target_class`/`direction` for relationships meant every relationship created via Manual Mapping needed a separate backfill step to reconstruct that information from the ontology after the fact.

## How to test

1. Open Manual Mapping, configure an entity's ID/label columns and some attribute mappings (including excluding one), save — reload and confirm all of it persisted, including the excluded attribute.
2. Configure a relationship's source/target columns, save — confirm `source_class`/`target_class`/`direction` are present on the saved relationship without needing any separate consistency-check pass.

## Note for maintainers

There's a companion fix we're holding back for now: `src/back/objects/mapping/Mapping.py` in our 0.7.1-based tree also (a) preserves an existing `excluded_attributes` list on update when the incoming payload omits it, and (b) backfills `source_class`/`target_class` from the property's domain/range when a relationship consistency-check finds them empty (the legacy-data counterpart to this PR's frontend fix). We saw `Mapping.py` has since grown a substantial schema-drift feature on `develop`, so we want to make sure our change still makes sense against that before proposing it — will follow up with a separate PR once we've checked.
