### PR TITLE
fix(mapping): preserve excluded_attributes on update, backfill relationship source/target class

### DIFF
--- a/src/back/objects/mapping/Mapping.py
+++ b/src/back/objects/mapping/Mapping.py
@@ -661,6 +661,8 @@ class Mapping:
             if m.get("ontology_class") == new_mapping["ontology_class"]:
                 if m.get("excluded") and "excluded" not in new_mapping:
                     new_mapping["excluded"] = True
+                if m.get("excluded_attributes") and "excluded_attributes" not in new_mapping:
+                    new_mapping["excluded_attributes"] = list(m["excluded_attributes"])
                 mappings[i] = new_mapping
                 was_update = True
                 break
@@ -709,6 +711,8 @@ class Mapping:
             if m.get("property") == new_mapping["property"]:
                 if m.get("excluded") and "excluded" not in new_mapping:
                     new_mapping["excluded"] = True
+                if m.get("excluded_attributes") and "excluded_attributes" not in new_mapping:
+                    new_mapping["excluded_attributes"] = list(m["excluded_attributes"])
                 mappings[i] = new_mapping
                 was_update = True
                 break
@@ -2349,10 +2353,26 @@ class Mapping:
         prop_uri = rel.get("property", "")
         prop_label = rel.get("property_label") or prop_uri
         sql_query = (rel.get("sql_query") or "").strip()
-        src_class = rel.get("source_class", "")
-        src_label = rel.get("source_class_label", "")
-        tgt_class = rel.get("target_class", "")
-        tgt_label = rel.get("target_class_label", "")
+
+        # Relationship mappings only carry source_class/target_class when the
+        # UI flow that saved them sent those fields explicitly. Manual Mapping
+        # never does (it only posts property/sql_query/source_id_column/
+        # target_id_column), so they persist as "" and entity resolution below
+        # fails even though the relationship is otherwise fully configured.
+        # Fall back to the ontology property's own rdfs:domain/rdfs:range,
+        # which is always parsed correctly (see /ontology/get-loaded-ontology)
+        # and is exactly what the Designer/Manual Mapping header ("EstudioPais
+        # -> Pais") already displays.
+        ont_prop = ont_props.get(prop_uri) or ont_prop_names.get(prop_label)
+
+        src_class = rel.get("source_class", "") or (
+            ont_prop.get("domain", "") if ont_prop else ""
+        )
+        src_label = rel.get("source_class_label", "") or src_class
+        tgt_class = rel.get("target_class", "") or (
+            ont_prop.get("range", "") if ont_prop else ""
+        )
+        tgt_label = rel.get("target_class_label", "") or tgt_class
         src_id_col = rel.get("source_id_column") or rel.get("source_column", "")
         tgt_id_col = rel.get("target_id_column") or rel.get("target_column", "")
 
@@ -2446,7 +2466,8 @@ class Mapping:
                 }
             )
 
-        ont_prop = ont_props.get(prop_uri) or ont_prop_names.get(prop_label)
+        # ont_prop was already resolved above to compute the src_class/tgt_class
+        # fallback; reuse it instead of looking it up a second time.
         if ont_prop:
             checks.append(
                 {


### PR DESCRIPTION
## What

Companion backend fix to #150 (the Manual Mapping save-state PR), in `src/back/objects/mapping/Mapping.py`:

- When updating an existing entity or relationship mapping, if the incoming payload omits `excluded_attributes` but the previous mapping had one, that list is now carried forward. Previously only the general `excluded` flag was preserved this way, not the concrete `excluded_attributes` list — so re-saving a mapping that had excluded attributes could silently re-include them.
- When resolving a relationship's `source_class`/`target_class` for consistency checks, if those fields are empty — as they always are for relationships saved via Manual Mapping, which never sends them — they're now backfilled from the corresponding ontology property's `rdfs:domain`/`rdfs:range` instead of being left empty.

## Why

#150 stops new Manual Mapping saves from losing `source_class`/`target_class`/`excluded_attributes` going forward. This PR is the counterpart for mappings that already exist without them (created before #150, or from any other code path that doesn't send those fields) — the consistency check now recovers what it needs from the ontology itself rather than reporting incomplete data for an otherwise-correctly-configured relationship.

## A note on how this PR came together

This is a delayed follow-up to #146–#150: when we first put those together, `Mapping.py` had since grown a substantial schema-drift feature on `develop` that we hadn't checked our change against, so we held it back. We've now verified this patch applies cleanly on top of that feature with no overlap at all — the drift-detection code and this fix touch entirely different methods — so there was nothing to reconcile, just due diligence to do first.

## How to test

1. Create an entity mapping with an excluded attribute, save, then re-save the mapping without explicitly re-sending `excluded_attributes` (e.g. via a code path that omits it) — the attribute should stay excluded instead of reappearing.
2. Create a relationship via Manual Mapping (which never sends `source_class`/`target_class`), then run the mapping consistency check — `source_class`/`target_class` should resolve from the property's domain/range instead of showing empty.
