### PR TITLE
fix(graphdb): correct SCRIPT_DIR path resolution in setup-lakebase.sh

### DIFF
--- a/changelogs/v0.7.1/lrubakhin_2026-08-30.log
+++ b/changelogs/v0.7.1/lrubakhin_2026-08-30.log
@@ -1,0 +1,22 @@
+## Fix SCRIPT_DIR path resolution in setup-lakebase.sh
+Context: scripts/bootstrap/setup-lakebase.sh failed immediately on a fresh
+local setup with `chmod: cannot access
+'scripts/_internal/check-deploy-prerequisites.sh': No such file or
+directory`. The script computes SCRIPT_DIR and does `cd "$SCRIPT_DIR/.."`,
+but since the script lives at scripts/bootstrap/setup-lakebase.sh (two
+levels below the repo root), that only ascends one level, landing in
+scripts/ instead of the repo root, so every relative path referenced
+afterward resolves incorrectly. Likely a regression from when the script
+was relocated from scripts/setup-lakebase.sh into scripts/bootstrap/.
+Changes:
+1. scripts/bootstrap/setup-lakebase.sh
+   Changed `cd "$SCRIPT_DIR/.."` to `cd "$SCRIPT_DIR/../.."` so the script
+   correctly resolves the repo root.
+Modified files:
+- scripts/bootstrap/setup-lakebase.sh
+- changelogs/v0.7.1/lrubakhin_2026-08-30.log
+Tests: Manual verification on Windows 11 (Git Bash / MINGW64):
+./scripts/bootstrap/setup-lakebase.sh — before fix, fails immediately with
+the chmod error above; after fix, correctly locates and chmods
+scripts/_internal/check-deploy-prerequisites.sh and proceeds past the
+preflight-check stage. No pytest suite covers this shell script.

--- a/scripts/bootstrap/setup-lakebase.sh
+++ b/scripts/bootstrap/setup-lakebase.sh
@@ -40,7 +40,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-cd "$SCRIPT_DIR/.."
+cd "$SCRIPT_DIR/../.."
 
 # Preflight CLI auth + tooling before any API calls.
 chmod +x scripts/_internal/check-deploy-prerequisites.sh


### PR DESCRIPTION
## Summary
`scripts/bootstrap/setup-lakebase.sh` couldn't run at all — it computes its
own directory but only ascends one level to find the repo root, when it
actually needs two (the script lives at `scripts/bootstrap/`, not
`scripts/`). This one-line fix corrects the `cd` target so the script can
locate `scripts/_internal/check-deploy-prerequisites.sh` and proceed.

## Linked Issue / milestone
No existing issue — issue creation is restricted on this repo, so this PR
serves as the report. Related to (but distinct from) #117, which fixed a
different failure in the same script (CLI auth-parsing, since resolved).
This bug is a path-resolution regression, likely introduced when the script
moved from `scripts/setup-lakebase.sh` into `scripts/bootstrap/` without
updating the `cd` depth accordingly.

## Plan
N/A — one-line bug fix, no `.planning/` entry.

## Type of change
- [x] fix — bug fix

## Author checklist
- [x] Conventional Commit PR title (`fix(graphdb): ...`)
- [x] `changelogs/<today>.log` updated 
- [ ] Tests added — *N/A: single-line shell path fix, no existing test coverage for this script to extend*
- [x] `uv run pytest tests/<scope>/` — *N/A, no Python changed*
- [ ] `pre-commit run --all-files` — *not run yet, will confirm*
- [x] No `src/agents/**` or MLflow-traced paths touched
- [x] No `src/mcp-server/**` touched
- [x] No `gsd-*` references introduced

## MLflow eval run
N/A — not an agent PR.

## Test plan
Manually verified end-to-end on Windows 11 (Git Bash / MINGW64):

    ./scripts/bootstrap/setup-lakebase.sh

Before fix:

    chmod: cannot access 'scripts/_internal/check-deploy-prerequisites.sh': No such file or directory

After fix: script locates the file, chmods it successfully, and proceeds
past the preflight-check stage.  

## Reviewer hint
1. Single-line change in `scripts/bootstrap/setup-lakebase.sh`: `cd "$SCRIPT_DIR/.."` → `cd "$SCRIPT_DIR/../.."`, correcting a directory-depth miscount after the script's relocation into `scripts/bootstrap/`.