### PR TITLE
fix(graphdb): use postgres generate-database-credential CLI subcommand

### DIFF
--- a/changelogs/v0.7.1/lrubakhin_2026-08-31.log
+++ b/changelogs/v0.7.1/lrubakhin_2026-08-31.log
@@ -1,0 +1,26 @@
+## Fix broken credential-minting API call in lakebase-perms.sh
+Context: scripts/bootstrap/lakebase-perms.sh minted the Lakebase Postgres
+JWT via `databricks api post /api/2.0/postgres/credentials --json
+'{"endpoint": ...}'`, which reproducibly returns `Error: Not Found` even
+for a valid, working Autoscaling endpoint (confirmed via a direct standalone
+call, and via the dedicated CLI subcommand succeeding for the same
+endpoint). Because the script uses `set -euo pipefail`, the resulting
+non-JSON error text piped into `python3 -c 'json.load(...)'` throws a
+JSONDecodeError and silently kills the whole script with no error message
+printed — surfacing only as a bare `Error 1` from `make bootstrap-lakebase`.
+Changes:
+1. scripts/bootstrap/lakebase-perms.sh
+   Replaced the raw `databricks api post /api/2.0/postgres/credentials`
+   passthrough with the dedicated `databricks postgres
+   generate-database-credential` CLI subcommand, which correctly mints the
+   credential for the same endpoint.
+Modified files:
+- scripts/bootstrap/lakebase-perms.sh
+- changelogs/v0.7.1/lrubakhin_2026-08-31.log
+Tests: Manual verification on Windows 11 (Git Bash / MINGW64, Databricks
+CLI v1.14.1): DATABRICKS_CONFIG_PROFILE=<profile> bash
+scripts/bootstrap/lakebase-perms.sh -i ontobricks-db -b production -d
+ontobricks_registry -s ontobricks_registry -a "" -a "" — before fix,
+silently exits 1 immediately after the credential-minting step with no
+error text; after fix, mints the JWT successfully and proceeds to apply
+schema migrations and (attempted) permission grants.

--- a/scripts/bootstrap/lakebase-perms.sh
+++ b/scripts/bootstrap/lakebase-perms.sh
@@ -199,8 +199,7 @@ echo
 # Mint a Lakebase JWT via the Autoscaling Postgres API. The legacy
 # ``/api/2.0/database/credentials`` mint cannot scope tokens to
 # Autoscaling-only project endpoints.
-PGPASSWORD="$(databricks api post /api/2.0/postgres/credentials \
-    --json "{\"endpoint\":\"${ENDPOINT_PATH}\"}" \
+PGPASSWORD="$(databricks postgres generate-database-credential "${ENDPOINT_PATH}" \
     | python3 -c 'import sys,json; print(json.load(sys.stdin).get("token",""))')"
 if [[ -z "$PGPASSWORD" ]]; then
     echo "ERROR: Failed to mint a Lakebase JWT for project '${INSTANCE}' on branch '${BRANCH}'." >&2


### PR DESCRIPTION
## Summary
`scripts/bootstrap/lakebase-perms.sh` minted its Lakebase Postgres
credential via `databricks api post /api/2.0/postgres/credentials --json
'{"endpoint": ...}'`. This call reproducibly returns `Error: Not Found`
for a valid, working Autoscaling project endpoint — confirmed both as a
standalone command and inside the script. Because the script runs under
`set -euo pipefail`, the non-JSON error text piped into the following
`python3 -c 'json.load(...)'` step throws a JSONDecodeError, which
silently kills the entire script with no error message — it just exits 1.
This PR replaces the raw API passthrough with the dedicated
`databricks postgres generate-database-credential` CLI subcommand, which
correctly mints the credential for the same endpoint.

## Linked Issue / milestone
No existing issue — issue creation is restricted on this repo, so this PR
serves as the report.

## Plan
N/A — targeted bug fix, no `.planning/` entry.

## Type of change
- [x] fix — bug fix

## Author checklist
- [x] Conventional Commit PR title (`fix(graphdb): ...`)
- [x] `changelogs/<today>.log` updated
- [ ] Tests added — N/A: single-line shell fix to a CLI invocation, no existing test coverage for this script to extend
- [x] `uv run pytest tests/<scope>/` — N/A, no Python changed
- [ ] `pre-commit run --all-files` — not run, will confirm if requested
- [x] No `src/agents/**` or MLflow-traced paths touched
- [x] No `src/mcp-server/**` touched
- [x] No `gsd-*` references introduced

## MLflow eval run
N/A — not an agent PR.

## Test plan
Manually verified on Windows 11 (Git Bash / MINGW64), Databricks CLI v1.14.1:

    DATABRICKS_CONFIG_PROFILE=<profile> bash scripts/bootstrap/lakebase-perms.sh \
      -i ontobricks-db -b production -d ontobricks_registry -s ontobricks_registry -a "" -a ""

Before fix: exits 1 silently, immediately after the credential-minting
step, no error text printed.

After fix: mints the JWT successfully, proceeds to apply schema
migrations and (skip) permission grants for non-existent apps as expected.

Also reproduced the underlying API failure directly, standalone:

    databricks api post /api/2.0/postgres/credentials \
      --json '{"endpoint":"projects/ontobricks-db/branches/production/endpoints/primary"}'
    → Error: Not Found

    databricks postgres generate-database-credential \
      "projects/ontobricks-db/branches/production/endpoints/primary"
    → returns a valid JSON credential

## Reviewer hint
1. Single-line swap in `scripts/bootstrap/lakebase-perms.sh`: replaced the raw `databricks api post /api/2.0/postgres/credentials` passthrough with `databricks postgres generate-database-credential "${ENDPOINT_PATH}"`, which correctly mints the same credential.