### PR TITLE
fix(graphdb): pin JSON output and surface real errors in lakebase-perms.sh

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -19,6 +19,7 @@ Thank you to everyone who has contributed to OntoBricks!
 | Sam Bryfczynski | [@sambryfczynski](https://github.com/sambryfczynski) | Databricks CLI profile auth for local development when PAT generation is blocked ([#49](https://github.com/databrickslabs/ontobricks/pull/49)) |
 | Andreas Niehaus | [@a-niehaus](https://github.com/a-niehaus) | Fix for Claude serving endpoints returning list-style `message.content` ([#107](https://github.com/databrickslabs/ontobricks/issues/107), [#109](https://github.com/databrickslabs/ontobricks/pull/109)) |
 | Brian Castelino | [@bcastelino](https://github.com/bcastelino) | Regression test for KG `/sync/filter` on non-DRAFT versions ([#110](https://github.com/databrickslabs/ontobricks/pull/110)) |
+| lrubakhin | [@lrubakhin](https://github.com/lrubakhin) | Lakebase credential minting fix and improved bootstrap diagnostics ([#157](https://github.com/databrickslabs/ontobricks/pull/157)) |
 | Ulrik Møller | [@ulsmo](https://github.com/ulsmo) | Contributor |
 | Mitul | [@kmitul](https://github.com/kmitul) | Contributor |
 

--- a/changelogs/v0.8.0/benoitcayladbx_2026-09-02.log
+++ b/changelogs/v0.8.0/benoitcayladbx_2026-09-02.log
@@ -1,0 +1,27 @@
+## Harden Lakebase credential error handling
+
+Context: PR #157 correctly switched credential minting to the dedicated
+Databricks CLI command, but malformed successful output still terminated
+silently under `set -e`. The follow-up preserves the contributor's original
+commit while making every credential failure observable and safe.
+
+Changes:
+
+1. scripts/bootstrap/lakebase-perms.sh
+   Capture CLI stderr separately from credential JSON, handle malformed JSON
+   without triggering an early shell exit, and avoid printing credential
+   response bodies.
+2. tests/units/scripts/test_lakebase_perms.py
+   Add a regression test proving malformed credential JSON reports diagnostics.
+3. CONTRIBUTORS.md
+   Credit @lrubakhin for the Lakebase credential minting and diagnostics fix.
+
+Modified files:
+- scripts/bootstrap/lakebase-perms.sh
+- tests/units/scripts/test_lakebase_perms.py
+- CONTRIBUTORS.md
+- changelogs/v0.8.0/benoitcayladbx_2026-09-02.log
+
+Tests: `uv run --frozen pytest -q -m "not scenario"` → 5764 passed,
+305 skipped, 6 deselected, 1 xfailed, 0 failed in 44.69s; targeted regression
+test → 3 passed; `bash -n scripts/bootstrap/lakebase-perms.sh` → passed.

--- a/changelogs/v0.8.0/lrubakhin_2026-09-01.log
+++ b/changelogs/v0.8.0/lrubakhin_2026-09-01.log
@@ -1,0 +1,35 @@
+## Fix silent failure in lakebase-perms.sh credential minting (PR #156 review)
+Context: PR #156 replaced the broken `databricks api post
+/api/2.0/postgres/credentials` call with `databricks postgres
+generate-database-credential`, but review feedback identified two
+remaining gaps: (1) the subcommand's output format is not guaranteed to
+be JSON without `--output json` — the CLI defaults to text/table unless
+the user's local config or DATABRICKS_OUTPUT_FORMAT already forces JSON,
+so the same silent JSONDecodeError death could recur on a differently
+configured machine; (2) the credential-minting call still had no error
+handling — a CLI failure (non-zero exit) or an unparseable response
+produced no diagnostic output at all, just a bare exit 1.
+Changes:
+1. scripts/bootstrap/lakebase-perms.sh
+   Added `--output json` to force JSON output explicitly. Captured
+   stdout+stderr from the CLI call and check its exit status directly
+   rather than only checking whether PGPASSWORD ended up empty. On CLI
+   failure or unparseable JSON, print the actual CLI error text before
+   calling _lakebase_print_diag_hints and exiting 1. Updated the
+   preceding comment to reference the current `postgres
+   generate-database-credential` subcommand (verified on CLI 1.14.1+)
+   instead of the legacy Autoscaling REST API description.
+Modified files:
+- scripts/bootstrap/lakebase-perms.sh
+- changelogs/v0.8.0/lrubakhin_2026-09-01.log
+Tests: Manual verification on Windows 11 (Git Bash / MINGW64, Databricks
+CLI v1.14.1), against develop branch:
+- Happy path: `bash scripts/bootstrap/lakebase-perms.sh -i ontobricks-db
+  -b production -d ontobricks_registry -s ontobricks_registry -a "" -a
+  ""` — completes successfully, applies schema migrations, skips
+  permission grants for non-existent apps as expected.
+- Failure path: temporarily forced ENDPOINT_PATH to a nonexistent
+  endpoint and re-ran — before this fix, silent exit 1 with zero output;
+  after this fix, prints "ERROR: Failed to mint a Lakebase JWT..." plus
+  the CLI's actual error text ("Error: Endpoint '...' not found") plus
+  full diagnostic hints, then exits 1.

--- a/scripts/bootstrap/lakebase-perms.sh
+++ b/scripts/bootstrap/lakebase-perms.sh
@@ -196,16 +196,32 @@ echo "Acting as: ${PGUSER}"
 echo "Apps     : ${APPS[*]}"
 echo
 
-# Mint a Lakebase JWT via the Autoscaling Postgres API. The legacy
-# ``/api/2.0/database/credentials`` mint cannot scope tokens to
-# Autoscaling-only project endpoints.
-PGPASSWORD="$(databricks api post /api/2.0/postgres/credentials \
-    --json "{\"endpoint\":\"${ENDPOINT_PATH}\"}" \
-    | python3 -c 'import sys,json; print(json.load(sys.stdin).get("token",""))')"
-if [[ -z "$PGPASSWORD" ]]; then
-    echo "ERROR: Failed to mint a Lakebase JWT for project '${INSTANCE}' on branch '${BRANCH}'." >&2
+# Mint a Lakebase JWT via `databricks postgres generate-database-credential`
+# (verified on Databricks CLI 1.14.1+). --output json is required: the CLI's
+# default output format is text/table unless the user's config or
+# DATABRICKS_OUTPUT_FORMAT already forces JSON, and without it the parser
+# below dies silently under `set -euo pipefail`.
+CRED_JSON="$(databricks postgres generate-database-credential "${ENDPOINT_PATH}" --output json 2>&1)" || {
+    echo "ERROR: Failed to mint a Lakebase JWT for project '${INSTANCE}' on branch '${BRANCH}' (CLI exited non-zero)." >&2
+    echo "$CRED_JSON" >&2
     _lakebase_print_diag_hints \
-        "postgres credentials API failed (endpoint: ${ENDPOINT_PATH})" \
+        "postgres generate-database-credential failed (endpoint: ${ENDPOINT_PATH})" \
+        "${INSTANCE}" "${BRANCH}" "${DATABASE}"
+    exit 1
+}
+PGPASSWORD="$(printf '%s' "$CRED_JSON" | python3 -c '
+import sys, json
+try:
+    data = json.load(sys.stdin)
+except json.JSONDecodeError:
+    sys.exit(1)
+print(data.get("token", ""), end="")
+')"
+if [[ -z "$PGPASSWORD" ]]; then
+    echo "ERROR: Failed to mint a Lakebase JWT for project '${INSTANCE}' on branch '${BRANCH}' — CLI succeeded but response was not valid JSON or had no token field." >&2
+    echo "$CRED_JSON" >&2
+    _lakebase_print_diag_hints \
+        "postgres generate-database-credential returned unparseable/empty credential (endpoint: ${ENDPOINT_PATH})" \
         "${INSTANCE}" "${BRANCH}" "${DATABASE}"
     exit 1
 fi

--- a/scripts/bootstrap/lakebase-perms.sh
+++ b/scripts/bootstrap/lakebase-perms.sh
@@ -201,25 +201,31 @@ echo
 # default output format is text/table unless the user's config or
 # DATABRICKS_OUTPUT_FORMAT already forces JSON, and without it the parser
 # below dies silently under `set -euo pipefail`.
-CRED_JSON="$(databricks postgres generate-database-credential "${ENDPOINT_PATH}" --output json 2>&1)" || {
+CRED_ERR_FILE="$(mktemp)"
+if ! CRED_JSON="$(databricks postgres generate-database-credential "${ENDPOINT_PATH}" --output json 2>"$CRED_ERR_FILE")"; then
+    CRED_ERROR="$(cat "$CRED_ERR_FILE")"
+    rm -f "$CRED_ERR_FILE"
     echo "ERROR: Failed to mint a Lakebase JWT for project '${INSTANCE}' on branch '${BRANCH}' (CLI exited non-zero)." >&2
-    echo "$CRED_JSON" >&2
+    [[ -n "$CRED_ERROR" ]] && printf '%s\n' "$CRED_ERROR" >&2
     _lakebase_print_diag_hints \
         "postgres generate-database-credential failed (endpoint: ${ENDPOINT_PATH})" \
         "${INSTANCE}" "${BRANCH}" "${DATABASE}"
     exit 1
-}
+fi
+CRED_WARNING="$(cat "$CRED_ERR_FILE")"
+rm -f "$CRED_ERR_FILE"
 PGPASSWORD="$(printf '%s' "$CRED_JSON" | python3 -c '
 import sys, json
 try:
     data = json.load(sys.stdin)
 except json.JSONDecodeError:
-    sys.exit(1)
-print(data.get("token", ""), end="")
+    data = {}
+token = data.get("token") if isinstance(data, dict) else ""
+print(token or "", end="")
 ')"
 if [[ -z "$PGPASSWORD" ]]; then
     echo "ERROR: Failed to mint a Lakebase JWT for project '${INSTANCE}' on branch '${BRANCH}' — CLI succeeded but response was not valid JSON or had no token field." >&2
-    echo "$CRED_JSON" >&2
+    [[ -n "$CRED_WARNING" ]] && printf '%s\n' "$CRED_WARNING" >&2
     _lakebase_print_diag_hints \
         "postgres generate-database-credential returned unparseable/empty credential (endpoint: ${ENDPOINT_PATH})" \
         "${INSTANCE}" "${BRANCH}" "${DATABASE}"

--- a/tests/units/scripts/test_lakebase_perms.py
+++ b/tests/units/scripts/test_lakebase_perms.py
@@ -1,0 +1,69 @@
+"""Regression tests for the Lakebase permission bootstrap script."""
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "scripts" / "bootstrap" / "lakebase-perms.sh"
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(content)
+    path.chmod(0o755)
+
+
+@pytest.mark.parametrize("credential_payload", ["not-json", "[]", '{"token":null}'])
+def test_invalid_credential_json_reports_diagnostics(
+    tmp_path: Path, credential_payload: str
+) -> None:
+    """A successful CLI call with invalid JSON must not fail silently."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_executable(
+        bin_dir / "databricks",
+        """#!/usr/bin/env bash
+if [[ "$1 $2" == "current-user me" ]]; then
+    printf '%s\n' '{"userName":"reviewer@example.com"}'
+elif [[ "$1 $2" == "api get" ]]; then
+    printf '%s\n' '{"endpoints":[{"name":"projects/test/branches/production/endpoints/primary","status":{"hosts":{"host":"test.database.cloud.databricks.com"}}}]}'
+elif [[ "$1 $2" == "postgres generate-database-credential" ]]; then
+    printf '%s\n' "$CREDENTIAL_PAYLOAD"
+else
+    exit 2
+fi
+""",
+    )
+    _write_executable(bin_dir / "psql", "#!/usr/bin/env bash\nexit 0\n")
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["CREDENTIAL_PAYLOAD"] = credential_payload
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(SCRIPT),
+            "-i",
+            "test",
+            "-b",
+            "production",
+            "-d",
+            "registry",
+            "-s",
+            "registry",
+            "-a",
+            "",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "CLI succeeded but response was not valid JSON" in result.stderr
+    assert "Lakebase diagnostics" in result.stderr


### PR DESCRIPTION
## Summary
Follow-up to #156 addressing review feedback. Two blocking issues fixed:
(1) `--output json` is now passed explicitly to `databricks postgres
generate-database-credential`, since the CLI's default output format is
text/table unless the user's config or `DATABRICKS_OUTPUT_FORMAT` already
forces JSON — without it, the same silent-death failure mode could recur
on a machine not already JSON-configured. (2) The credential-minting call
now captures stdout+stderr and checks the CLI's exit status directly,
rather than relying solely on `PGPASSWORD` being empty as the failure
signal — a CLI error or unparseable response now prints the actual error
text and diagnostic hints instead of a bare, silent `exit 1`. Also updated
the stale comment above the mint to reference the current subcommand
(verified on CLI 1.14.1+) instead of the old Autoscaling REST API
description.

## Linked Issue / milestone
Follow-up to #156. This PR targets `develop` per review feedback (integration
happens on `develop`, not `master`).

## Type of change
- [x] fix — bug fix

## Author checklist
- [x] Conventional Commit PR title
- [x] `changelogs/<today>.log` updated (`changelogs/v0.8.0/...`, per review feedback on version targeting)
- [ ] Tests added — N/A: shell script fix, no existing pytest coverage for this script
- [x] `uv run pytest tests/<scope>/` — N/A, no Python changed
- [ ] `pre-commit run --all-files` — not run, will confirm if requested
- [x] No `src/agents/**` or MLflow-traced paths touched
- [x] No `src/mcp-server/**` touched
- [x] No `gsd-*` references introduced

## Test plan
Manual verification on Windows 11 (Git Bash / MINGW64), Databricks CLI v1.14.1, against `develop`:

**Happy path:**

    DATABRICKS_CONFIG_PROFILE=<profile> bash scripts/bootstrap/lakebase-perms.sh \
      -i ontobricks-db -b production -d ontobricks_registry -s ontobricks_registry -a "" -a ""

Succeeds as before, applies schema migrations.

**Failure path** (temporarily forced `ENDPOINT_PATH` to a nonexistent endpoint to exercise the credential-minting error branch specifically):

Before this fix: silent `exit 1`, zero output.
After this fix:

    ERROR: Failed to mint a Lakebase JWT for project 'ontobricks-db' on branch 'production' (CLI exited non-zero).
    Error: Endpoint 'projects/ontobricks-db/branches/production/endpoints/does-not-exist' not found
      Lakebase diagnostics (postgres generate-database-credential failed ...):
      ...

## Reviewer hint
1. `scripts/bootstrap/lakebase-perms.sh`: added `--output json`; wrapped the CLI call in `... || { ... exit 1; }` to capture and surface failures; wrapped the JSON parse in `try/except json.JSONDecodeError` so an unparseable response also surfaces a real error instead of an uncaught traceback or silent empty-token fallthrough.
