### PR TITLE
fix(lakebase): follow next_page_token when listing Postgres projects

### DIFF
--- a/src/back/core/databricks/lakebase/LakebaseAuth.py
+++ b/src/back/core/databricks/lakebase/LakebaseAuth.py
@@ -335,34 +335,41 @@ class LakebaseAuth:
         api = getattr(self._w, "api_client", None)
         if api is None or not hasattr(api, "do"):
             return None
-        projects = (api.do("GET", "/api/2.0/postgres/projects") or {}).get(
-            "projects"
-        ) or []
-        for project in projects:
-            project_path = project.get("name") or ""
-            if not project_path:
-                continue
-            branches = (
-                api.do("GET", f"/api/2.0/postgres/{project_path}/branches") or {}
-            ).get("branches") or []
-            for branch in branches:
-                branch_path = branch.get("name") or ""
-                if not branch_path:
+        # /api/2.0/postgres/projects is paginated - a workspace with more
+        # projects than fit on one page silently hides later ones from a
+        # single unpaginated call, so we must follow next_page_token.
+        page_token: Optional[str] = None
+        while True:
+            query = {"page_token": page_token} if page_token else None
+            resp = api.do("GET", "/api/2.0/postgres/projects", query=query) or {}
+            projects = resp.get("projects") or []
+            for project in projects:
+                project_path = project.get("name") or ""
+                if not project_path:
                     continue
-                endpoints = (
-                    api.do("GET", f"/api/2.0/postgres/{branch_path}/endpoints")
-                    or {}
-                ).get("endpoints") or []
-                for endpoint in endpoints:
-                    hosts = (endpoint.get("status") or {}).get("hosts") or {}
-                    h = (hosts.get("host") or "").strip().lower()
-                    ro = (hosts.get("read_only_host") or "").strip().lower()
-                    if host in (h, ro):
-                        endpoint_path = endpoint.get("name") or ""
-                        if endpoint_path:
-                            self._endpoint_resource = endpoint_path
-                        return project_path.rsplit("/", 1)[-1]
-        return None
+                branches = (
+                    api.do("GET", f"/api/2.0/postgres/{project_path}/branches") or {}
+                ).get("branches") or []
+                for branch in branches:
+                    branch_path = branch.get("name") or ""
+                    if not branch_path:
+                        continue
+                    endpoints = (
+                        api.do("GET", f"/api/2.0/postgres/{branch_path}/endpoints")
+                        or {}
+                    ).get("endpoints") or []
+                    for endpoint in endpoints:
+                        hosts = (endpoint.get("status") or {}).get("hosts") or {}
+                        h = (hosts.get("host") or "").strip().lower()
+                        ro = (hosts.get("read_only_host") or "").strip().lower()
+                        if host in (h, ro):
+                            endpoint_path = endpoint.get("name") or ""
+                            if endpoint_path:
+                                self._endpoint_resource = endpoint_path
+                            return project_path.rsplit("/", 1)[-1]
+            page_token = resp.get("next_page_token")
+            if not page_token:
+                return None
 
     def _ensure_workspace(self) -> None:
         """Lazily build the workspace client."""


### PR DESCRIPTION
<!--
PR Template — Cursor-Native Superpowers (CNS) methodology
See docs/PR_REVIEW_CHECKLIST.md for the reviewer's pass.
-->

## Summary

 `_lookup_via_postgres_api` calls `GET /api/2.0/postgres/projects` once without following `next_page_token`. That endpoint paginates at 10 projects/page, so in workspaces with more than 10 Postgres projects, an project past page 1 is invisible to this lookup — causing the misleading error "No Lakebase Autoscaling endpoint matched... legacy Provisioned instances are not supported", even with a valid, correctly-permissioned project.

 Confirmed in production (2026-09-04): the project was on page 2 of 19. Fix: loop over `next_page_token` until exhausted.

<!-- One paragraph: what changes, why now. Avoid restating the diff. -->

## Linked Issue / milestone

Closes #160

## Plan

N/A — single-file fix, no formal plan doc for this one.

<!-- For T4 (agent feature) work, link the SPEC too: -->
<!-- `.planning/<slug>/SPEC.md` -->

## Type of change

- [ ] feat — new feature
- [x] fix — bug fix
- [ ] docs — documentation only
- [ ] refactor — no behaviour change
- [ ] test — tests only
- [ ] perf — perf improvement
- [ ] ci / build / chore — tooling

## Author checklist

- [x] Conventional Commit PR title (`<type>(<scope>): <subject>`).
- [ ] `changelogs/<today>.log` updated with title + context + numbered changes + files + test result.
- [ ] Tests added or modified for every behaviour change.
- [ ] `uv run pytest tests/<scope>/` green locally.
- [ ] `pre-commit run --all-files` clean (or skipped hooks documented).
- [ ] If `src/agents/**` or any MLflow-traced LLM path changed:
  - [ ] `SPEC.md` present in `.planning/<slug>/`.
  - [ ] `tests/eval/datasets/<agent>/dataset.jsonl` has ≥20 examples (new) or ≥10 (change).
  - [ ] MLflow eval run URI in PR body below.
  - [ ] Judge score ≥ baseline + delta, or explicit waiver here.
- [ ] If `src/mcp-server/**` changed: `uv run pytest tests/mcp/ -m mcp` green.
- [x] No `gsd-*` references re-introduced.

## MLflow eval run

<!-- For agent PRs only. Paste the run URI: -->
<!-- https://<workspace>.databricks.com/ml/experiments/<id>/runs/<run-id> -->

## Test plan

- [ ] `uv run pytest tests/ -m "not e2e and not property and not eval" --cov-fail-under=90`
- [ ] Per-package coverage thresholds (`scripts/check_coverage.py`) green for touched packages.
- [ ] If new MCP tool: `uv run pytest tests/mcp/integration/test_tool_schemas.py` includes it.

## Reviewer hint

See `docs/PR_REVIEW_CHECKLIST.md`. Numbered items map 1:1 to comments — `#3: missing OntoBricksError subclass for new condition` is more useful than "fix error handling".
