### PR TITLE
fix(api): resolve four undefined names and gate F821 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,13 @@ jobs:
       - name: Lint with flake8
         run: uv run flake8 src/ tests/ --max-line-length=100 --extend-ignore=E203,W503
 
+      # Blocking, repo-wide, and deliberately narrow: F821 is an undefined name,
+      # which is a NameError waiting for the line to execute — never a style
+      # opinion, so it needs no burn-down period. Kept separate from the advisory
+      # ruff step below so the whole-repo backlog cannot mask a new one.
+      - name: Ruff (gate — undefined names, F821)
+        run: uv run --frozen ruff check --select F821 --output-format=concise src/ tests/
+
       # M3.P1 (advisory) — ruff runs in report-only mode against the changed files
       # of the PR. The full repo currently has ~3000 lint findings; we'll burn
       # them down over time. Pre-commit hook gates NEW code (changed lines only).

--- a/changelogs/v0.8.0/benoitcayladbx_2026-09-11.log
+++ b/changelogs/v0.8.0/benoitcayladbx_2026-09-11.log
@@ -1,0 +1,36 @@
+## Fix undefined names and enforce F821
+
+Context: `GET /api/v1/digitaltwin/triples` raised `NameError` for every request
+because its backend selection referenced undefined variable `be`. Three more
+undefined names prevented enabling a focused repository-wide F821 quality gate.
+This change resolves GitHub issue #163 and rebases pull request #164 onto develop.
+
+Changes:
+
+1. src/api/routers/digitaltwin.py
+   Select the view or graph table using the documented `backend` parameter.
+2. src/api/routers/internal/ontology.py
+   Use the built-in generic `dict` for the evaluated local annotation.
+3. src/back/core/external/pitfalls/runner.py
+   Import the lazily loaded sentiment analyzer under `TYPE_CHECKING`.
+4. src/back/core/graphdb/delta/DeltaBase.py
+   Resolve the Delta warehouse with the existing Delta-specific helper.
+5. tests/units/dtwin/test_digitaltwin_api.py
+   Cover graph and view backend table selection and the reported NameError.
+6. .github/workflows/ci.yml
+   Add a blocking, frozen, repository-wide Ruff F821 gate.
+
+Modified files:
+- .github/workflows/ci.yml
+- changelogs/v0.8.0/benoitcayladbx_2026-09-11.log
+- src/api/routers/digitaltwin.py
+- src/api/routers/internal/ontology.py
+- src/back/core/external/pitfalls/runner.py
+- src/back/core/graphdb/delta/DeltaBase.py
+- tests/units/dtwin/test_digitaltwin_api.py
+
+Tests: `uv run --frozen pytest -q -m "not scenario"` -> 5859 passed, 304
+skipped, 6 deselected, 1 xfailed, 23 warnings in 46.48s.
+`uv run --frozen ruff check --select F821 --output-format=concise src tests`
+-> all checks passed. The two triples regression tests failed with `NameError`
+before the fix and passed after it.

--- a/src/api/routers/digitaltwin.py
+++ b/src/api/routers/digitaltwin.py
@@ -858,7 +858,7 @@ async def dt_triples(
 
     table = (
         effective_view_table(domain, settings).strip()
-        if be == "view"
+        if backend == "view"
         else effective_graph_query_table(domain, settings, store=store)
     )
     if not table:

--- a/src/api/routers/internal/ontology.py
+++ b/src/api/routers/internal/ontology.py
@@ -1322,7 +1322,7 @@ async def accept_business_rules_suggestions(
         data = await request.json()
         domain = get_domain(session_mgr)
 
-        added: Dict[str, int] = {}
+        added: dict[str, int] = {}
         rejected: list = []
         duplicates: list = []
         dirty = False

--- a/src/back/core/external/pitfalls/runner.py
+++ b/src/back/core/external/pitfalls/runner.py
@@ -14,10 +14,13 @@ from __future__ import annotations
 
 from collections import Counter
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Set, Tuple
 
 # rdflib is always available (core dep)
 from rdflib import Graph, OWL, RDF, RDFS, URIRef
+
+if TYPE_CHECKING:  # annotation-only — nltk is imported lazily at the call site.
+    from nltk.sentiment import SentimentIntensityAnalyzer
 
 # Optional ML deps — imported lazily; None when the pitfalls extra is not installed.
 try:

--- a/src/back/core/graphdb/delta/DeltaBase.py
+++ b/src/back/core/graphdb/delta/DeltaBase.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from typing import Any, Optional, Tuple
 
 from back.core.databricks import is_databricks_app
-from back.core.helpers import get_databricks_host_and_token, resolve_delta_warehouse_id
+from back.core.helpers import (
+    get_databricks_host_and_token,
+    resolve_delta_warehouse_id,
+)
 from back.core.logging import get_logger
 
 logger = get_logger(__name__)
@@ -50,7 +53,7 @@ def resolve_credentials(
     """Return ``(host, token, warehouse_id)`` for build tasks."""
     if settings is not None:
         host, token = get_databricks_host_and_token(domain, settings)
-        warehouse_id = resolve_warehouse_id(domain, settings)
+        warehouse_id = resolve_delta_warehouse_id(domain, settings)
     else:
         db = getattr(domain, "databricks", None) or {}
         host = db.get("host", "")

--- a/tests/units/dtwin/test_digitaltwin_api.py
+++ b/tests/units/dtwin/test_digitaltwin_api.py
@@ -486,3 +486,68 @@ class TestResolveCohortContext:
         assert graph_name == "dom_V1"
         assert store is mock_store.return_value
         assert isinstance(service, CohortService)
+
+
+# ---------------------------------------------------------------------------
+# GET /triples — backend selection
+# ---------------------------------------------------------------------------
+
+
+class TestDtTriplesBackendSelection:
+    """``backend`` picks the queried relation; neither branch may NameError.
+
+    Regression guard for the undefined ``be`` reference that made every call to
+    ``GET /api/v1/digitaltwin/triples`` raise ``NameError`` — the conditional's
+    test is evaluated whatever ``backend`` is, so the default path failed too.
+    """
+
+    def _store(self):
+        store = MagicMock()
+        store.paginated_count.return_value = 1
+        store.paginated_triples.return_value = [
+            {"subject": "s", "predicate": "p", "object": "o"}
+        ]
+        return store
+
+    @patch("api.routers.digitaltwin.effective_view_table", return_value="c.s.view_V1")
+    @patch(
+        "api.routers.digitaltwin.effective_graph_query_table",
+        return_value="c.s.graph_V1",
+    )
+    @patch("api.routers.digitaltwin.get_graphdb")
+    @patch("api.routers.digitaltwin.DigitalTwin.resolve_domain")
+    async def test_graph_backend_queries_graph_table(
+        self, mock_resolve, mock_store, _query, _view
+    ):
+        from api.routers.digitaltwin import dt_triples
+
+        mock_resolve.return_value = MagicMock()
+        store = self._store()
+        mock_store.return_value = store
+
+        resp = await dt_triples(
+            backend="graph", session_mgr=MagicMock(), settings=MagicMock()
+        )
+
+        assert resp.total == 1
+        assert store.paginated_count.call_args[0][0] == "c.s.graph_V1"
+
+    @patch("api.routers.digitaltwin.effective_view_table", return_value="c.s.view_V1")
+    @patch(
+        "api.routers.digitaltwin.effective_graph_query_table",
+        return_value="c.s.graph_V1",
+    )
+    @patch("api.routers.digitaltwin.get_graphdb")
+    @patch("api.routers.digitaltwin.DigitalTwin.resolve_domain")
+    async def test_view_backend_queries_view_table(
+        self, mock_resolve, mock_store, _query, _view
+    ):
+        from api.routers.digitaltwin import dt_triples
+
+        mock_resolve.return_value = MagicMock()
+        store = self._store()
+        mock_store.return_value = store
+
+        await dt_triples(backend="view", session_mgr=MagicMock(), settings=MagicMock())
+
+        assert store.paginated_count.call_args[0][0] == "c.s.view_V1"


### PR DESCRIPTION
## Summary

`GET /api/v1/digitaltwin/triples` raised `NameError` for every request because its table-selection expression referenced undefined name `be` instead of the documented `backend` query parameter. Both `backend=graph` and `backend=view` failed because Python evaluates the conditional test before selecting either branch.

This PR is rebased onto `develop`, fixes all four repository-wide F821 findings, adds regression coverage for both triples backends, and adds a blocking F821-only Ruff gate.

Fixes #163.

## Changes

1. **`src/api/routers/digitaltwin.py`** — use `backend` to select the view or graph relation.
2. **`src/api/routers/internal/ontology.py`** — replace the evaluated undefined `Dict` local annotation with `dict`.
3. **`src/back/core/external/pitfalls/runner.py`** — import `SentimentIntensityAnalyzer` under `TYPE_CHECKING`; runtime loading remains lazy.
4. **`src/back/core/graphdb/delta/DeltaBase.py`** — use the already imported Delta-specific warehouse resolver in `resolve_credentials`.
5. **`tests/units/dtwin/test_digitaltwin_api.py`** — cover graph and view table selection. Both tests reproduce the original `NameError` before the fix.
6. **`.github/workflows/ci.yml`** — add a blocking, frozen, repository-wide `ruff check --select F821` gate, separate from the advisory broad Ruff check.
7. **`changelogs/v0.8.0/benoitcayladbx_2026-09-11.log`** — record the develop-targeted fix and verification.

## Verification

- Regression RED: 2 failed with `NameError: name 'be' is not defined`.
- Regression GREEN: 2 passed.
- `uv run --frozen ruff check --select F821 --output-format=concise src tests` → all checks passed.
- `uv run --frozen pytest -q -m "not scenario"` → **5859 passed, 304 skipped, 6 deselected, 1 xfailed**, 23 warnings in 46.48s.

The existing Black baseline reports formatting drift in four touched files; this PR intentionally avoids unrelated whole-file formatting churn.