### PR TITLE
fix(license): align project metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,11 @@ by the Databricks CLI.
 Product overview, screenshots and videos:
 [ontobricks.org](https://ontobricks.org/).
 
+## License
+
+OntoBricks, including OntoViz, is source-available under the
+[Databricks License](LICENSE.txt).
+
 ## Project Support
 
 Please note that all projects in the /databrickslabs github account are provided

--- a/changelogs/v0.8.0/benoitcayladbx_2026-09-13.log
+++ b/changelogs/v0.8.0/benoitcayladbx_2026-09-13.log
@@ -1,0 +1,39 @@
+## Align project licensing
+
+Context: GitHub issue #169 identified conflicting MIT, Apache 2.0, and
+Databricks License claims across first-party project surfaces. The Databricks
+License is authoritative for OntoBricks and its OntoViz component; third-party
+dependency and vendored-component notices remain unchanged.
+
+Changes:
+
+1. README.md, docs/INFO.md, docs/product.md
+   Identify OntoBricks as source-available under the Databricks License.
+2. docs/architecture.md, docs/development.md
+   Align the first-party OntoViz license documentation with the project license.
+3. docs/deployment.md
+   Correct the description of the shipped project license and notice files.
+4. src/api/constants.py, src/shared/fastapi/main.py
+   Publish Databricks License metadata in both generated OpenAPI schemas.
+5. src/front/static/global/ontoviz/ontoviz.js
+   Replace the stale MIT header with the Databricks License and canonical link.
+6. src/front/templates/about.html
+   Point the existing license link at the master branch.
+7. tests/contract/test_openapi_contract.py
+   Cover Databricks License metadata for both main and external OpenAPI schemas.
+
+Modified files:
+- README.md
+- docs/INFO.md
+- docs/architecture.md
+- docs/deployment.md
+- docs/development.md
+- docs/product.md
+- src/api/constants.py
+- src/front/static/global/ontoviz/ontoviz.js
+- src/front/templates/about.html
+- src/shared/fastapi/main.py
+- tests/contract/test_openapi_contract.py
+
+Tests: uv run --frozen pytest -q -m "not scenario" → 5861 passed, 304 skipped,
+6 deselected, 32 warnings in 46.70s

--- a/docs/INFO.md
+++ b/docs/INFO.md
@@ -14,7 +14,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License">
+  <img src="https://img.shields.io/badge/license-Databricks-blue.svg" alt="Databricks License">
   <img src="https://img.shields.io/badge/python-3.10+-blue.svg" alt="Python">
   <img src="https://img.shields.io/badge/fastapi-0.109+-green.svg" alt="FastAPI">
 </p>
@@ -557,7 +557,7 @@ make help
 
 ## License
 
-MIT License - see [LICENSE](LICENSE)
+Databricks License - see [LICENSE.txt](../LICENSE.txt)
 
 ## Resources
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2486,7 +2486,8 @@ No external dependencies required (uses vanilla JavaScript and CSS).
 
 ### License
 
-MIT License - OntoViz is open source and can be used in commercial projects.
+OntoViz is part of OntoBricks and is licensed under the
+[Databricks License](../LICENSE.txt).
 
 ---
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1501,7 +1501,7 @@ and unit tests — **the Databricks CLI does not apply it**.
 |------|-----|
 | `src/` | App code. Includes `src/mcp-server/` (MCP `source_code_path`) and `src/jobs/` (graph-analytics workspace file). |
 | `run.py`, `app.yaml`, `pyproject.toml`, `uv.lock`, `requirements.txt` | Process entry + dependency install |
-| `LICENSE.txt`, `NOTICE.txt` | Apache notices |
+| `LICENSE.txt`, `NOTICE.txt` | Databricks License and project notice |
 | Catalogued `docs/*.md` | Help Center (`/api/help/docs/{slug}`) — allow-list in `src/api/routers/internal/help.py` |
 | `docs/images/`, `docs/screenshots/` | Help Center assets |
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -98,7 +98,7 @@ These packages are used by the MCP server (`src/mcp-server/`) which runs as a se
 | **Version** | 1.0.0 |
 | **Location** | `src/front/static/global/ontoviz/ontoviz.js`, `src/front/static/global/ontoviz/css/` |
 | **Description** | Custom entity-relationship visual editor for ontology design |
-| **License** | MIT |
+| **License** | [Databricks License](../LICENSE.txt) |
 | **Author** | OntoBricks Team |
 
 OntoViz is a lightweight, self-contained library for creating and managing ER diagrams. It provides:
@@ -263,7 +263,8 @@ new gridjs.Grid({
 
 | License | Packages |
 |---------|----------|
-| **MIT** | FastAPI, pydantic, pydantic-settings, Bootstrap, Bootstrap Icons, Sigma.js, Graphology, Grid.js, Chart.js, OntoViz, strawberry-graphql, pytest, pytest-asyncio, pytest-cov, black, flake8 |
+| **Databricks License** | OntoViz (first-party OntoBricks component) |
+| **MIT** | FastAPI, pydantic, pydantic-settings, Bootstrap, Bootstrap Icons, Sigma.js, Graphology, Grid.js, Chart.js, strawberry-graphql, pytest, pytest-asyncio, pytest-cov, black, flake8 |
 | **BSD-3-Clause** | Uvicorn, Starlette, Jinja2, itsdangerous, RDFLib, python-dotenv, httpx, NetworkX |
 | **Apache-2.0** | databricks-sql-connector, databricks-sdk, pyarrow, python-multipart, aiofiles, requests, fastmcp, MLflow, pyshacl, responses, playwright |
 | **LGPL-3.0** | psycopg (binary + pool) |

--- a/docs/product.md
+++ b/docs/product.md
@@ -213,7 +213,7 @@ OntoBricks is the **only** solution that combines all of the following in a sing
 - LLM-automated (ontology generation + data mapping)
 - Graph-visualizing (interactive graph viewer)
 - Industry-standard ready (FIBO, CDISC, IOF)
-- Open-source (MIT license)
+- Source-available under the [Databricks License](../LICENSE.txt)
 
 ---
 
@@ -271,7 +271,7 @@ databricks apps deploy --app-name ontobricks
 
 | Resource                 | Link                                                |
 | ------------------------ | --------------------------------------------------- |
-| Source Code              | GitHub repository (MIT license)                     |
+| Source Code              | GitHub repository ([Databricks License](../LICENSE.txt)) |
 | Documentation            | Full user guide, architecture docs, API reference   |
 | Automated Pipeline Guide | Step-by-step: tables to graph viewer in 4 clicks |
 | Import Guide             | FIBO, CDISC, IOF import instructions                |
@@ -385,7 +385,7 @@ OntoBricks provides an end-to-end, web-based solution that runs directly on Data
 
 #### Deliverable
 
-A **production-ready Databricks App** (open-source, MIT license) that:
+A **production-ready, source-available Databricks App** under the [Databricks License](../LICENSE.txt) that:
 
 - Deploys in minutes via `databricks apps deploy`
 - Requires only a SQL Warehouse and (optionally) a Model Serving endpoint

--- a/src/api/constants.py
+++ b/src/api/constants.py
@@ -111,8 +111,8 @@ EXTERNAL_API_CONTACT: Dict[str, str] = {
 }
 
 EXTERNAL_API_LICENSE_INFO: Dict[str, str] = {
-    "name": "Apache 2.0",
-    "url": "https://www.apache.org/licenses/LICENSE-2.0.html",
+    "name": "Databricks License",
+    "url": "https://github.com/databrickslabs/ontobricks/blob/master/LICENSE.txt",
 }
 
 __all__ = [

--- a/src/front/static/global/ontoviz/ontoviz.js
+++ b/src/front/static/global/ontoviz/ontoviz.js
@@ -3,7 +3,8 @@
  * A lightweight library for creating and managing ER diagrams
  * 
  * @version 1.0.0
- * @license MIT
+ * @license Databricks License
+ * @see https://github.com/databrickslabs/ontobricks/blob/master/LICENSE.txt
  */
 
 (function(global) {

--- a/src/front/templates/about.html
+++ b/src/front/templates/about.html
@@ -131,7 +131,7 @@
             <div class="card-body">
                 <p><strong>Version:</strong> {{ app_version }}</p>
                 <p><strong>Status:</strong> <span class="badge bg-success">Active</span></p>
-                <p class="mb-0"><strong>License:</strong> <a href="https://github.com/databrickslabs/ontobricks/blob/develop/LICENSE.txt" target="_blank" rel="noopener" class="text-decoration-none">Databricks License</a></p>
+                <p class="mb-0"><strong>License:</strong> <a href="https://github.com/databrickslabs/ontobricks/blob/master/LICENSE.txt" target="_blank" rel="noopener" class="text-decoration-none">Databricks License</a></p>
             </div>
         </div>
 

--- a/src/shared/fastapi/main.py
+++ b/src/shared/fastapi/main.py
@@ -599,8 +599,8 @@ def create_app() -> FastAPI:
             "url": "https://github.com/databricks/ontobricks",
         },
         license_info={
-            "name": "Apache 2.0",
-            "url": "https://www.apache.org/licenses/LICENSE-2.0.html",
+            "name": "Databricks License",
+            "url": "https://github.com/databrickslabs/ontobricks/blob/master/LICENSE.txt",
         },
         lifespan=lifespan,
     )

--- a/tests/contract/test_openapi_contract.py
+++ b/tests/contract/test_openapi_contract.py
@@ -45,6 +45,13 @@ class TestOpenAPISchemaShape:
         assert "title" in info
         assert len(info["title"]) > 0
 
+    def test_openapi_declares_databricks_license(self, client):
+        license_info = client.get("/openapi.json").json()["info"]["license"]
+        assert license_info == {
+            "name": "Databricks License",
+            "url": "https://github.com/databrickslabs/ontobricks/blob/master/LICENSE.txt",
+        }
+
 
 @pytest.mark.contract
 @pytest.mark.integration
@@ -120,7 +127,10 @@ class TestMCPContractPaths:
         assert "graph_backend" in tags["Domain"]
         assert "materialized graph" in tags["GraphQL"]
         assert spec["info"]["contact"]["name"] == "OntoBricks Support"
-        assert spec["info"]["license"]["name"] == "Apache 2.0"
+        assert spec["info"]["license"] == {
+            "name": "Databricks License",
+            "url": "https://github.com/databrickslabs/ontobricks/blob/master/LICENSE.txt",
+        }
 
 
 @pytest.mark.contract


### PR DESCRIPTION
## Summary

- make the Databricks License authoritative across README, product docs, deployment docs, and UI metadata
- update both OpenAPI schemas from Apache 2.0 to the Databricks License
- license first-party OntoViz under the Databricks License while preserving third-party notices
- add contract coverage for both OpenAPI surfaces

## Tests

- `uv run --frozen pytest -q -m "not scenario"` — 5861 passed, 304 skipped, 6 deselected

Closes #169