### PR TITLE
fix(frontend): load D3.js from jsdelivr instead of d3js.org

### DIFF
--- a/src/front/static/query/js/query-ontology-viewer.js
+++ b/src/front/static/query/js/query-ontology-viewer.js
@@ -11,7 +11,7 @@
 const OntologyViewer = (() => {
     const MODAL_ID = 'ontologyViewerModal';
     const CONTAINER_ID = 'ontologyViewerContainer';
-    const D3_CDN = 'https://d3js.org/d3.v7.min.js';
+    const D3_CDN = 'https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js';
 
     let _modal = null;
     let _zoom = null;

--- a/src/front/static/query/js/query-sigmagraph.js
+++ b/src/front/static/query/js/query-sigmagraph.js
@@ -86,7 +86,7 @@ var SigmaGraph = (function () {
     }
 
     var _GRAPH_LIB_URLS = [
-        'https://d3js.org/d3.v7.min.js',
+        'https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js',
         'https://cdnjs.cloudflare.com/ajax/libs/graphology/0.26.0/graphology.umd.min.js',
         'https://cdn.jsdelivr.net/npm/graphology-library@0.8.0/dist/graphology-library.min.js',
         'https://cdnjs.cloudflare.com/ajax/libs/sigma.js/3.0.2/sigma.min.js'

--- a/src/front/static/registry/js/registry.js
+++ b/src/front/static/registry/js/registry.js
@@ -899,7 +899,7 @@ document.addEventListener('DOMContentLoaded', function () {
     //  BRIDGES
     // =====================================================================
 
-    const D3_CDN = 'https://d3js.org/d3.v7.min.js';
+    const D3_CDN = 'https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js';
     const BRIDGES_VIEW_KEY = 'ontobricks-bridges-view';
     const NODE_PALETTE = [
         '#4e79a7', '#f28e2b', '#e15759', '#76b7b2', '#59a14f',

--- a/src/front/templates/partials/mapping/_mapping_design.html
+++ b/src/front/templates/partials/mapping/_mapping_design.html
@@ -116,4 +116,4 @@
 </div>
 
 <!-- D3.js Library -->
-<script src="https://d3js.org/d3.v7.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script>

--- a/src/front/templates/partials/ontology/_ontology_map.html
+++ b/src/front/templates/partials/ontology/_ontology_map.html
@@ -138,4 +138,4 @@
 </div>
 
 <!-- D3.js Library -->
-<script src="https://d3js.org/d3.v7.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script>


### PR DESCRIPTION
Reopened against `0.9.0` after `develop` was deleted. GitHub cannot reopen #149 (closed PR + missing base), so this is a successor of #149 with the same commits. Original author: @jeremiaspf. Please rebase onto current `0.9.0` before review — expect conflicts.

---

## What

Switches D3.js from `https://d3js.org/d3.v7.min.js` to `https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js` in every file that loads it:

- `src/front/static/query/js/query-ontology-viewer.js` (Query → Ontology Viewer)
- `src/front/static/query/js/query-sigmagraph.js` (query result graph, Sigma.js)
- `src/front/static/registry/js/registry.js` (Registry bridges map)
- `src/front/templates/partials/ontology/_ontology_map.html` (ontology map template)
- `src/front/templates/partials/mapping/_mapping_design.html` (Mapping designer panel template)

(`src/front/static/ontology/js/ontology-swrl.js` gets the same change as part of the companion Designer-UI PR, since that file needed unrelated fixes too.)

## Why

`d3js.org` is blocked in networks with restricted outbound access — which is common for Databricks Apps deployed in corporate environments. When that happens, every D3-based visualization fails to load entirely: the SWRL rule graph, the ontology viewer, the query result graph, the Registry bridges map, and the Mapping designer map. jsDelivr resolves cleanly in those environments and serves the same D3 v7 build.

## How to test

In an environment where `d3js.org` is blocked (or simulate by blocking it at the OS/proxy level), open any of the five screens above — they should render their D3 visualization instead of failing silently.