### PR TITLE
fix(mapping): stop discarding stale auto-load responses, always clear loading state, keep column-role menu open

### DIFF
--- a/src/front/static/mapping/js/mapping-design.js
+++ b/src/front/static/mapping/js/mapping-design.js
@@ -1624,11 +1624,14 @@ function initEntityPanel(classUri, className, existingMapping, classInfo) {
     });
     _updateEntityAttrToggleBtn();
 
-    // Auto-load query data in background when there is an existing mapping with SQL
+    // Auto-load query data in background when there is an existing mapping with SQL.
+    // Pass the generation captured now, at schedule time, so the response isn't
+    // discarded if initEntityPanel has already finished mounting by the time it arrives.
     if (existingMapping?.sql_query) {
+        const scheduledGeneration = EntityPanelState._generation;
         EntityPanelState._autoLoadTimer = setTimeout(() => {
             EntityPanelState._autoLoadTimer = null;
-            runEntityPanelQuery({ autoLoad: true });
+            runEntityPanelQuery({ autoLoad: true, generation: scheduledGeneration });
         }, 100);
     }
 }
@@ -1642,8 +1645,12 @@ async function runEntityPanelQuery(options = {}) {
         return;
     }
     
-    // Capture the generation at call time so we can detect stale responses
-    const capturedGeneration = EntityPanelState._generation;
+    // Capture the generation at call time so we can detect stale responses.
+    // A caller that scheduled this ahead of time (the auto-load timer) passes
+    // its own captured generation explicitly; otherwise capture it now.
+    const capturedGeneration = (options && options.generation != null)
+        ? options.generation
+        : EntityPanelState._generation;
     
     const previewLimit = parseInt(document.getElementById('epPreviewLimit')?.value) || 10;
     const btn = document.getElementById('epRunQueryBtn');
@@ -1660,15 +1667,14 @@ async function runEntityPanelQuery(options = {}) {
         });
         const result = await response.json();
         
-        // Discard stale response if the user switched to a different entity
-        if (currentPanelType !== 'entity' || capturedGeneration !== EntityPanelState._generation) return;
-        
         if (result.success) {
             EntityPanelState.columns = result.columns;
             EntityPanelState.rows = result.rows || [];
             
             if (!EntityPanelState.idColumn || !result.columns.includes(EntityPanelState.idColumn)) {
-                EntityPanelState.idColumn = null;
+                // Previously saved id column is gone from this result set — fall
+                // back to the first available column instead of leaving it unset.
+                EntityPanelState.idColumn = result.columns[0] || null;
             }
             if (EntityPanelState.labelColumn && !result.columns.includes(EntityPanelState.labelColumn)) {
                 EntityPanelState.labelColumn = null;
@@ -1677,7 +1683,7 @@ async function runEntityPanelQuery(options = {}) {
             autoMapEntityColumns(result.columns);
             renderEntityPanelGrid();
             const epSummary = document.getElementById('epMappingSummary');
-            if (epSummary) epSummary.style.display = 'none';
+            if (epSummary) epSummary.style.display = '';
             const epLoading = document.getElementById('epMappingLoading');
             if (epLoading) epLoading.style.display = 'none';
             const epGrid = document.getElementById('epMappingGrid');
@@ -1704,9 +1710,17 @@ async function runEntityPanelQuery(options = {}) {
         if (statusEl) statusEl.innerHTML = '<span class="text-danger"><i class="bi bi-x-circle"></i> Error</span>';
         showNotification('Error: ' + error.message, 'error');
     } finally {
-        if (capturedGeneration === EntityPanelState._generation && btn) {
+        // Always restore the button, regardless of generation — otherwise a
+        // panel switch mid-query leaves "Refreshing..." stuck permanently.
+        if (btn) {
             btn.disabled = false;
             btn.innerHTML = '<i class="bi bi-arrow-clockwise"></i> Refresh';
+        }
+        if (capturedGeneration !== EntityPanelState._generation) {
+            // Response belongs to a superseded generation: still hide the
+            // loading spinner so it doesn't stay stuck if the user comes back.
+            const epLoadingStale = document.getElementById('epMappingLoading');
+            if (epLoadingStale) epLoadingStale.style.display = 'none';
         }
     }
 }
@@ -1717,16 +1731,12 @@ function renderEntityPanelGrid() {
     if (!headerRow || !tbody) return;
     
     headerRow.innerHTML = EntityPanelState.columns.map(col => {
-        let badge = '';
-        if (EntityPanelState.idColumn === col) {
-            badge = '<span class="badge bg-primary">ID</span>';
-        } else if (EntityPanelState.labelColumn === col) {
-            badge = '<span class="badge bg-info">Label</span>';
-        } else {
-            const attr = Object.entries(EntityPanelState.attributeMappings).find(([a, c]) => c === col);
-            if (attr) badge = `<span class="badge bg-secondary">${attr[0]}</span>`;
-            else badge = '<span class="badge bg-light text-muted border">Map</span>';
-        }
+        const badges = [];
+        if (EntityPanelState.idColumn === col) badges.push('<span class="badge bg-primary">ID</span>');
+        if (EntityPanelState.labelColumn === col) badges.push('<span class="badge bg-info">Label</span>');
+        const attr = Object.entries(EntityPanelState.attributeMappings).find(([a, c]) => c === col);
+        if (attr) badges.push(`<span class="badge bg-secondary">${attr[0]}</span>`);
+        let badge = badges.length ? badges.join(' ') : '<span class="badge bg-light text-muted border">Map</span>';
         if (EntityPanelState.driftedColumns.has(col)) {
             badge += ' <span class="badge bg-warning text-dark" ' +
                 'title="This column no longer exists in the source table">' +
@@ -1774,20 +1784,43 @@ function showEntityColumnMenu(th, column) {
     document.body.appendChild(menu);
     
     menu.querySelectorAll('.dropdown-item').forEach(item => {
-        item.addEventListener('click', () => {
+        item.addEventListener('click', (e) => {
+            e.stopPropagation();
             const action = item.dataset.action;
-            if (EntityPanelState.idColumn === column) EntityPanelState.idColumn = null;
-            if (EntityPanelState.labelColumn === column) EntityPanelState.labelColumn = null;
-            Object.keys(EntityPanelState.attributeMappings).forEach(a => {
-                if (EntityPanelState.attributeMappings[a] === column) delete EntityPanelState.attributeMappings[a];
-            });
-            
-            if (action === 'id') EntityPanelState.idColumn = column;
-            else if (action === 'label') EntityPanelState.labelColumn = column;
-            else if (action === 'attr') EntityPanelState.attributeMappings[item.dataset.attr] = column;
 
-            menu.remove();
+            if (action === 'id') {
+                // Unique across the query, and toggles off on its own column.
+                EntityPanelState.idColumn = (EntityPanelState.idColumn === column) ? null : column;
+            } else if (action === 'label') {
+                EntityPanelState.labelColumn = (EntityPanelState.labelColumn === column) ? null : column;
+            } else if (action === 'attr') {
+                const attrName = item.dataset.attr;
+                const alreadyHere = EntityPanelState.attributeMappings[attrName] === column;
+                // One attribute maps to a single column...
+                delete EntityPanelState.attributeMappings[attrName];
+                // ...and one column maps to a single attribute.
+                Object.keys(EntityPanelState.attributeMappings).forEach(a => {
+                    if (EntityPanelState.attributeMappings[a] === column) delete EntityPanelState.attributeMappings[a];
+                });
+                if (!alreadyHere) EntityPanelState.attributeMappings[attrName] = column;
+            } else if (action === 'clear') {
+                if (EntityPanelState.idColumn === column) EntityPanelState.idColumn = null;
+                if (EntityPanelState.labelColumn === column) EntityPanelState.labelColumn = null;
+                Object.keys(EntityPanelState.attributeMappings).forEach(a => {
+                    if (EntityPanelState.attributeMappings[a] === column) delete EntityPanelState.attributeMappings[a];
+                });
+            }
+
+            const openColumn = column;
             renderEntityPanelGrid();
+            if (action === 'clear') {
+                menu.remove();
+            } else {
+                // Reopen the menu on the same column so multiple roles can be
+                // assigned in a row without having to reopen it each time.
+                const th = document.querySelector(`#epResultsHeader th[data-col="${CSS.escape(openColumn)}"]`);
+                if (th) showEntityColumnMenu(th, openColumn);
+            }
         });
     });
     
@@ -1974,8 +2007,6 @@ async function runRelPanelQuery(options = {}) {
             credentials: 'same-origin'
         });
         const result = await response.json();
-        
-        if (currentPanelType !== 'relationship') return;
         
         if (result.success) {
             RelPanelState.columns = result.columns;


### PR DESCRIPTION
Reopened against `0.9.0` after `develop` was deleted. GitHub cannot reopen #153 (closed PR + missing base), so this is a successor of #153 with the same commits. Original author: @jeremiaspf. Please rebase onto current `0.9.0` before review — expect conflicts.

---

## What

Three related fixes in the entity/relationship mapping panels (`mapping-design.js`), rebuilt from scratch against the current `develop`:

**Auto-load race condition.** The saved SQL query auto-loads in the background when a panel opens. Its response is now matched against the generation captured *when the auto-load was scheduled*, not re-read at response time — so it's no longer silently discarded if the panel finishes mounting before the response arrives. Both the entity and relationship panels also stop discarding a response just because the user switched panel/generation in the meantime; the Refresh button and loading spinner are now unconditionally cleared in the completion path, so a slow query can no longer leave the button stuck on "Refreshing..." or the spinner stuck visible. If a previously saved ID column is no longer present in a refreshed result set, the first available column is now auto-selected instead of left unset.

**Column-role menu.** The per-column menu (assign ID / Label / an attribute to a result column) now stays open across clicks and reopens on the same column after each assignment, instead of closing after every single click — so multiple roles can be assigned across columns in one pass without reopening the menu each time. The existing "Clear" menu item (already present in the markup, added along with the rest of this menu's current design) now actually clears a column's roles — previously the click handler had no branch for `data-action="clear"` at all, so clicking it silently did nothing.

## Why

All three are UX papercuts that make the mapping panels tedious or misleading to use in practice: a stuck "Refreshing..." button after switching panels, a saved ID column silently reset to nothing after a schema change, and a "Clear" button that visibly exists but doesn't work.

## Note on scope — rebuilt against current develop

This PR replaces a fix we originally wrote against 0.7.1 and held back, because `develop` had since reworked this same file substantially (a schema-drift feature: auto-load of live-schema warnings, drift badges, `guardedCloseMappingPanel`). We rebuilt the fix from scratch directly against the current file rather than porting the old patch, dropping one piece of it that no longer applies: our original fix also renamed a literal DOM id (`savePanelBtn` → `manualSavePanelBtn`) shared between the entity and relationship panels' save buttons. That whole button is gone on `develop` — replaced by auto-save on panel dismiss — so there's nothing left to rename; the two leftover `getElementById('savePanelBtn')` calls in `updateEntityPanelSaveBtn`/`updateRelPanelSaveBtn` are harmless dead code (always `null`, guarded by `if (saveBtn)`) and we left them alone rather than touching code unrelated to what this PR fixes.

## How to test

1. Open an entity/relationship panel with a saved SQL query on a slow connection, switch to a different panel before the auto-load response arrives — the Refresh button and loading spinner should not get stuck.
2. Change the source table's schema so a previously mapped ID column no longer exists, refresh the query — the ID column should auto-select the first available column instead of staying unset.
3. Open the column-role menu on a result grid, assign ID to one column and an attribute to another without the menu closing in between, then use "Clear" on a column — it should actually clear that column's assigned roles.